### PR TITLE
Add tests for PR parsing and grouping

### DIFF
--- a/internal/pr/grouping_test.go
+++ b/internal/pr/grouping_test.go
@@ -1,0 +1,139 @@
+package pr
+
+import (
+	"testing"
+)
+
+func samplePRs() []PRInfo {
+	return []PRInfo{
+		{Owner: "giantswarm", Repo: "flux-app", Number: 1, Title: "Update dependency foo to v1.0.0"},
+		{Owner: "giantswarm", Repo: "flux-app", Number: 2, Title: "Bump bar from 1.0 to 2.0"},
+		{Owner: "giantswarm", Repo: "kyverno-app", Number: 10, Title: "Update dependency foo to v1.0.0"},
+		{Owner: "giantswarm", Repo: "kyverno-app", Number: 11, Title: "Update dependency baz to v3.0.0"},
+		{Owner: "giantswarm", Repo: "kyverno-app", Number: 12, Title: "Bump bar from 2.0 to 3.0"},
+	}
+}
+
+func TestGroupByRepo(t *testing.T) {
+	groups := GroupByRepo(samplePRs())
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+
+	// kyverno-app has 3 PRs so it should be first (sorted by count desc)
+	if groups[0].Key != "giantswarm/kyverno-app" {
+		t.Errorf("first group key = %q, want %q", groups[0].Key, "giantswarm/kyverno-app")
+	}
+	if groups[0].Count != 3 {
+		t.Errorf("first group count = %d, want 3", groups[0].Count)
+	}
+
+	if groups[1].Key != "giantswarm/flux-app" {
+		t.Errorf("second group key = %q, want %q", groups[1].Key, "giantswarm/flux-app")
+	}
+	if groups[1].Count != 2 {
+		t.Errorf("second group count = %d, want 2", groups[1].Count)
+	}
+}
+
+func TestGroupByDependency(t *testing.T) {
+	groups := GroupByDependency(samplePRs())
+
+	// Should produce groups for: foo (2 PRs), bar (2 PRs), baz (1 PR)
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %d", len(groups))
+	}
+
+	groupMap := make(map[string]PRGroup)
+	for _, g := range groups {
+		groupMap[g.Key] = g
+	}
+
+	if g, ok := groupMap["foo"]; !ok {
+		t.Error("expected group for dependency 'foo'")
+	} else if g.Count != 2 {
+		t.Errorf("foo group count = %d, want 2", g.Count)
+	}
+
+	if g, ok := groupMap["bar"]; !ok {
+		t.Error("expected group for dependency 'bar'")
+	} else if g.Count != 2 {
+		t.Errorf("bar group count = %d, want 2", g.Count)
+	}
+
+	if g, ok := groupMap["baz"]; !ok {
+		t.Error("expected group for dependency 'baz'")
+	} else if g.Count != 1 {
+		t.Errorf("baz group count = %d, want 1", g.Count)
+	}
+}
+
+func TestGroupByDependency_unknownTitle(t *testing.T) {
+	prs := []PRInfo{
+		{Owner: "org", Repo: "repo", Number: 1, Title: "Fix a random bug"},
+	}
+	groups := GroupByDependency(prs)
+
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Key != "(unknown)" {
+		t.Errorf("group key = %q, want %q", groups[0].Key, "(unknown)")
+	}
+}
+
+func TestGroupByRepo_empty(t *testing.T) {
+	groups := GroupByRepo(nil)
+	if len(groups) != 0 {
+		t.Fatalf("expected 0 groups for nil input, got %d", len(groups))
+	}
+}
+
+func TestGroupByDependency_empty(t *testing.T) {
+	groups := GroupByDependency(nil)
+	if len(groups) != 0 {
+		t.Fatalf("expected 0 groups for nil input, got %d", len(groups))
+	}
+}
+
+func TestSortedGroups_tiebreakByKey(t *testing.T) {
+	prs := []PRInfo{
+		{Owner: "org", Repo: "bravo", Number: 1, Title: "Update dependency x to v1"},
+		{Owner: "org", Repo: "alpha", Number: 2, Title: "Update dependency y to v1"},
+	}
+	groups := GroupByRepo(prs)
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	// Same count (1 each), so should be alphabetical
+	if groups[0].Key != "org/alpha" {
+		t.Errorf("first group key = %q, want %q (alphabetical tiebreak)", groups[0].Key, "org/alpha")
+	}
+	if groups[1].Key != "org/bravo" {
+		t.Errorf("second group key = %q, want %q", groups[1].Key, "org/bravo")
+	}
+}
+
+func TestGroupPreservesPRData(t *testing.T) {
+	prs := []PRInfo{
+		{Owner: "org", Repo: "repo", Number: 42, Title: "Bump foo from 1.0 to 2.0", URL: "https://github.com/org/repo/pull/42", Author: "app/dependabot"},
+	}
+	groups := GroupByRepo(prs)
+
+	if len(groups) != 1 || len(groups[0].PRs) != 1 {
+		t.Fatalf("expected exactly 1 group with 1 PR")
+	}
+
+	pr := groups[0].PRs[0]
+	if pr.Number != 42 {
+		t.Errorf("PR number = %d, want 42", pr.Number)
+	}
+	if pr.URL != "https://github.com/org/repo/pull/42" {
+		t.Errorf("PR URL = %q, want %q", pr.URL, "https://github.com/org/repo/pull/42")
+	}
+	if pr.Author != "app/dependabot" {
+		t.Errorf("PR author = %q, want %q", pr.Author, "app/dependabot")
+	}
+}

--- a/internal/pr/parse_test.go
+++ b/internal/pr/parse_test.go
@@ -1,0 +1,191 @@
+package pr
+
+import (
+	"testing"
+)
+
+func TestParseRepoFromURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "standard GitHub URL",
+			url:       "https://github.com/giantswarm/flux-app",
+			wantOwner: "giantswarm",
+			wantRepo:  "flux-app",
+		},
+		{
+			name:      "GitHub URL with trailing slash",
+			url:       "https://github.com/giantswarm/flux-app/",
+			wantOwner: "giantswarm",
+			wantRepo:  "flux-app",
+		},
+		{
+			name:      "GitHub URL with .git suffix",
+			url:       "https://github.com/giantswarm/flux-app.git",
+			wantOwner: "giantswarm",
+			wantRepo:  "flux-app",
+		},
+		{
+			name:      "GitHub URL with path segments",
+			url:       "https://github.com/giantswarm/flux-app/pull/42",
+			wantOwner: "giantswarm",
+			wantRepo:  "flux-app",
+		},
+		{
+			name:      "SSH-style URL",
+			url:       "git@github.com/giantswarm/flux-app",
+			wantOwner: "giantswarm",
+			wantRepo:  "flux-app",
+		},
+		{
+			name:    "empty string",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "unrelated URL",
+			url:     "https://example.com/foo",
+			wantErr: true,
+		},
+		{
+			name:    "only owner, no repo",
+			url:     "https://github.com/giantswarm",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := ParseRepoFromURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got owner=%q repo=%q", owner, repo)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tt.wantOwner {
+				t.Errorf("owner = %q, want %q", owner, tt.wantOwner)
+			}
+			if repo != tt.wantRepo {
+				t.Errorf("repo = %q, want %q", repo, tt.wantRepo)
+			}
+		})
+	}
+}
+
+func TestExtractDependencyName(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		// Renovate: "Update dependency X to Y"
+		{
+			name:  "renovate update dependency",
+			title: "Update dependency github.com/foo/bar to v1.2.3",
+			want:  "github.com/foo/bar",
+		},
+		{
+			name:  "renovate update dependency case insensitive",
+			title: "update dependency lodash to 4.17.21",
+			want:  "lodash",
+		},
+		// Renovate: "Update X to Y" (without "dependency")
+		{
+			name:  "renovate update without dependency keyword",
+			title: "Update golang.org/x/net to v0.5.0",
+			want:  "golang.org/x/net",
+		},
+		// Renovate: "Update module X to Y"
+		{
+			name:  "renovate update module",
+			title: "Update module github.com/aws/aws-sdk-go to v1.44.0",
+			want:  "github.com/aws/aws-sdk-go",
+		},
+		// Renovate: "Update github-actions action X to Y"
+		{
+			name:  "renovate update github-actions action",
+			title: "Update github-actions action actions/checkout to v4",
+			want:  "actions/checkout",
+		},
+		// Renovate: "Pin dependency X to Y"
+		{
+			name:  "renovate pin dependency",
+			title: "Pin dependency typescript to 5.3.3",
+			want:  "typescript",
+		},
+		// Renovate: "Replace dependency X with Y"
+		{
+			name:  "renovate replace dependency",
+			title: "Replace dependency io/ioutil with os",
+			want:  "io/ioutil",
+		},
+		// Renovate: "Lock file maintenance"
+		{
+			name:  "renovate lock file maintenance",
+			title: "Lock file maintenance",
+			want:  "Lock file maintenance",
+		},
+		// Dependabot: "Bump X from Y to Z"
+		{
+			name:  "dependabot bump from to",
+			title: "Bump lodash from 4.17.20 to 4.17.21",
+			want:  "lodash",
+		},
+		{
+			name:  "dependabot bump scoped package",
+			title: "Bump github.com/spf13/cobra from 1.8.0 to 1.9.1",
+			want:  "github.com/spf13/cobra",
+		},
+		// Dependabot: "Bump the X group"
+		{
+			name:  "dependabot bump group",
+			title: "Bump the go-deps group across 3 directories with 5 updates",
+			want:  "go-deps",
+		},
+		{
+			name:  "dependabot bump group with updates",
+			title: "Bump the npm-production group with 2 updates",
+			want:  "npm-production",
+		},
+		// Dependabot: "Bump X to Y"
+		{
+			name:  "dependabot bump to",
+			title: "Bump actions/checkout to v4",
+			want:  "actions/checkout",
+		},
+		// Edge cases
+		{
+			name:  "empty title",
+			title: "",
+			want:  "",
+		},
+		{
+			name:  "unrecognized title",
+			title: "Fix a bug in the widget",
+			want:  "",
+		},
+		{
+			name:  "whitespace-padded title",
+			title: "  Update dependency foo to v1.0.0  ",
+			want:  "foo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractDependencyName(tt.title)
+			if got != tt.want {
+				t.Errorf("ExtractDependencyName(%q) = %q, want %q", tt.title, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `parse_test.go` with table-driven tests for `ParseRepoFromURL` and `ExtractDependencyName` (covers Renovate and Dependabot title patterns, edge cases)
- Add `grouping_test.go` with tests for `GroupByRepo`, `GroupByDependency`, empty inputs, sort tiebreaks, and PR data preservation

## Test plan

- All 25 tests pass via `go test ./internal/pr/`


Made with [Cursor](https://cursor.com)