### PR TITLE
Add README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Timo Derstappen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,22 @@ make install
 
 ## Setup
 
-Marge requires a GitHub personal access token with repo scope. Export it as an environment variable:
+Marge requires a GitHub personal access token. Export it as an environment variable:
 
 ```bash
 export GITHUB_TOKEN="ghp_..."
 ```
+
+**Classic token:** needs the `repo` scope.
+
+**Fine-grained token:** select the repositories you want marge to manage, then grant these permissions:
+
+| Permission | Access | Why |
+|------------|--------|-----|
+| Pull requests | Read & write | Approve and merge PRs |
+| Checks | Read | Wait for CI status |
+| Commit statuses | Read | Read combined commit status |
+| Metadata | Read | Required by default |
 
 ## Usage
 
@@ -98,7 +109,7 @@ marge self-update     # Update to the latest release
    - Checks combined commit status and check runs; polls for up to 5 minutes if pending.
    - Approves the PR if not already approved.
    - If auto-merge is enabled, lets the merge queue handle it.
-   - Otherwise determines the merge method (squash preferred) and merges directly.
+   - Otherwise merges via squash.
 4. Displays a live-updating table with PR status throughout.
 
 ## Development
@@ -112,4 +123,4 @@ make help           # Show all available targets
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+MIT -- see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Add a README covering what marge does, installation options, setup, CLI usage with flags and examples, how the PR processing flow works, and development commands.
- Add MIT LICENSE file so the license reference in the README resolves.
- Document both classic (`repo` scope) and fine-grained token permissions for setup.
- Fix merge method description to accurately reflect the implementation (always squash, not "squash preferred").

## Test plan
- [x] Verify README renders correctly on GitHub (tables, links, code blocks)
- [x] Verify LICENSE link in README resolves to the new file