### PR TITLE
Fix CI check hanging when repo uses only GitHub Actions check runs

### DIFF
--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -135,7 +135,7 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	if combinedState == "failure" || combinedState == "error" {
 		return combinedState, nil
 	}
-	if combinedState == "pending" {
+	if combinedState == "pending" && len(combined.Statuses) > 0 {
 		return "pending", nil
 	}
 


### PR DESCRIPTION
## Summary

- The combined commit status API returns `"pending"` by default when no commit statuses exist on a ref. Repos using GitHub Actions (check runs) instead of the older commit status API would always see this phantom `"pending"`, causing marge to poll until the 5-minute timeout even when all check runs had already passed.
- Fix: only treat combined status as `"pending"` when there are actual status objects (`len(combined.Statuses) > 0`).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run marge against a repo that uses only GitHub Actions check runs (no commit statuses) and verify it proceeds to approve/merge without hanging

Made with [Cursor](https://cursor.com)