### PR TITLE
Discover self-hosted Renovate PRs authored by the user

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -245,6 +245,56 @@ func searchPRs(ctx context.Context, client *github.Client, query string) ([]pr.P
 		}
 	}
 
+	// Also search for self-authored dependency update PRs in user's own repos.
+	// This catches PRs created by self-hosted Renovate running under the user's PAT.
+	selfQuery := fmt.Sprintf("%s is:pr is:open archived:false user:%s author:%s", query, login, login)
+	selfQuery = strings.TrimSpace(selfQuery)
+
+	selfOpts := &github.SearchOptions{
+		Sort:        "updated",
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+
+	for {
+		result, resp, err := client.Search.Issues(ctx, selfQuery, selfOpts)
+		if err != nil {
+			return nil, fmt.Errorf("search failed: %w", err)
+		}
+
+		for _, issue := range result.Issues {
+			url := issue.GetHTMLURL()
+			if seen[url] {
+				continue
+			}
+
+			title := issue.GetTitle()
+			if !pr.IsDependencyUpdateTitle(title) {
+				continue
+			}
+
+			seen[url] = true
+
+			owner, repo, err := extractOwnerRepo(url)
+			if err != nil {
+				continue
+			}
+
+			allPRs = append(allPRs, pr.PRInfo{
+				Owner:  owner,
+				Repo:   repo,
+				Number: issue.GetNumber(),
+				Title:  title,
+				URL:    url,
+				Author: issue.GetUser().GetLogin(),
+			})
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		selfOpts.Page = resp.NextPage
+	}
+
 	return allPRs, nil
 }
 

--- a/internal/pr/parse.go
+++ b/internal/pr/parse.go
@@ -39,6 +39,23 @@ var dependencyPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)bump ([\w\-./]+(?:/[\w\-./]+)*) to `),
 }
 
+// IsDependencyUpdateTitle returns true if the PR title looks like an automated
+// dependency update (Renovate or Dependabot), regardless of who authored it.
+func IsDependencyUpdateTitle(title string) bool {
+	title = strings.TrimSpace(title)
+	lower := strings.ToLower(title)
+
+	// Conventional commit with deps scope: "chore(deps):", "fix(deps):", etc.
+	if idx := strings.Index(lower, ":"); idx != -1 {
+		if strings.Contains(lower[:idx], "deps") {
+			return true
+		}
+	}
+
+	// Known dependency update title patterns (Renovate/Dependabot)
+	return ExtractDependencyName(title) != ""
+}
+
 func ExtractDependencyName(title string) string {
 	title = strings.TrimSpace(title)
 	for _, pat := range dependencyPatterns {

--- a/internal/pr/parse_test.go
+++ b/internal/pr/parse_test.go
@@ -189,3 +189,95 @@ func TestExtractDependencyName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDependencyUpdateTitle(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		want  bool
+	}{
+		// Conventional commit with deps scope (self-hosted Renovate)
+		{
+			name:  "chore(deps) update",
+			title: "chore(deps): update eslint monorepo to v10 (major)",
+			want:  true,
+		},
+		{
+			name:  "fix(deps) update",
+			title: "fix(deps): update dependency foo to v2",
+			want:  true,
+		},
+		{
+			name:  "chore(deps) pin",
+			title: "chore(deps): pin dependencies",
+			want:  true,
+		},
+		{
+			name:  "chore(deps) terraform",
+			title: "chore(deps): update terraform aws to v6",
+			want:  true,
+		},
+		{
+			name:  "chore(deps) terraform ignition",
+			title: "chore(deps): update terraform ignition to v2",
+			want:  true,
+		},
+		// Standard Renovate titles (app-authored)
+		{
+			name:  "update dependency",
+			title: "Update dependency github.com/foo/bar to v1.2.3",
+			want:  true,
+		},
+		{
+			name:  "update module",
+			title: "Update module github.com/aws/aws-sdk-go to v1.44.0",
+			want:  true,
+		},
+		{
+			name:  "lock file maintenance",
+			title: "Lock file maintenance",
+			want:  true,
+		},
+		// Standard Dependabot titles
+		{
+			name:  "bump from to",
+			title: "Bump lodash from 4.17.20 to 4.17.21",
+			want:  true,
+		},
+		{
+			name:  "bump group",
+			title: "Bump the go-deps group across 3 directories with 5 updates",
+			want:  true,
+		},
+		// Non-dependency PRs
+		{
+			name:  "regular PR",
+			title: "Fix a bug in the widget",
+			want:  false,
+		},
+		{
+			name:  "feature PR",
+			title: "Add new authentication flow",
+			want:  false,
+		},
+		{
+			name:  "chore without deps scope",
+			title: "chore: clean up CI config",
+			want:  false,
+		},
+		{
+			name:  "empty title",
+			title: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsDependencyUpdateTitle(tt.title)
+			if got != tt.want {
+				t.Errorf("IsDependencyUpdateTitle(%q) = %v, want %v", tt.title, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an additional search pass in `searchPRs` that finds PRs authored by the authenticated user in their own repos, filtered by dependency update title patterns
- Adds `IsDependencyUpdateTitle()` to detect conventional commit `deps` scope (e.g. `chore(deps):`) and existing Renovate/Dependabot title formats
- Fixes self-hosted Renovate PRs (running under a PAT) not being discovered because they are authored by the user rather than `app/renovate`

## Test plan

- [x] Unit tests for `IsDependencyUpdateTitle` covering real PR titles (`chore(deps): update eslint monorepo to v10`, `chore(deps): update terraform aws to v6`, etc.) and negative cases
- [x] All existing tests pass
- [x] `go build ./...` succeeds

Made with [Cursor](https://cursor.com)