### PR TITLE
Improve table display and merge error details

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,13 +92,21 @@ func runOnce(ctx context.Context, client *github.Client, query string) error {
 		return nil
 	}
 
+	infoLabel := "Repository"
+	infoFn := pr.InfoFunc(pr.RepoInfoFunc)
+
 	// Interactive mode: if no query provided, let user pick a group
 	if query == "" {
-		selected, err := interactiveSelect(prs)
+		selected, specificGroup, err := interactiveSelect(prs)
 		if err != nil {
 			return err
 		}
 		prs = selected
+
+		if specificGroup && grouping == "repo" {
+			infoLabel = "Dependency"
+			infoFn = pr.DependencyInfoFunc
+		}
 	}
 
 	if len(prs) == 0 {
@@ -114,13 +122,9 @@ func runOnce(ctx context.Context, client *github.Client, query string) error {
 		indices[i] = status.Add(p)
 	}
 
-	pr.PrintTableHeader(os.Stdout)
-	// Print initial rows
+	pr.PrintTableHeader(os.Stdout, infoLabel)
 	for _, e := range status.Snapshot() {
-		prLabel := fmt.Sprintf("#%d", e.PR.Number)
-		prLink := pr.MakeHyperlink(prLabel, e.PR.URL)
-		repoName := fmt.Sprintf("%s/%s", e.PR.Owner, e.PR.Repo)
-		_, _ = fmt.Fprintf(os.Stdout, "%-10s %-50s %s\n", prLink, repoName, e.State.String())
+		pr.PrintRow(os.Stdout, e, infoFn)
 	}
 
 	// Start table refresh ticker
@@ -137,7 +141,7 @@ func runOnce(ctx context.Context, client *github.Client, query string) error {
 			case <-stopRefresh:
 				return
 			case <-ticker.C:
-				pr.UpdateTable(os.Stdout, status.Snapshot())
+				pr.UpdateTable(os.Stdout, status.Snapshot(), infoLabel, infoFn)
 			}
 		}
 	}()
@@ -162,7 +166,7 @@ func runOnce(ctx context.Context, client *github.Client, query string) error {
 	close(stopRefresh)
 	<-refreshStopped
 
-	pr.UpdateTable(os.Stdout, status.Snapshot())
+	pr.UpdateTable(os.Stdout, status.Snapshot(), infoLabel, infoFn)
 
 	fmt.Fprintf(os.Stderr, "\n%s\n", status.FormatSummary())
 
@@ -180,8 +184,6 @@ func searchPRs(ctx context.Context, client *github.Client, query string) ([]pr.P
 		authorFilters = []string{"author:app/renovate", "author:app/dependabot"}
 	}
 
-	// Get authenticated user's login so we can also search their own repos
-	// (bots in personal repos don't add the owner as a reviewer).
 	me, _, err := client.Users.Get(ctx, "")
 	if err != nil {
 		return nil, fmt.Errorf("getting authenticated user: %w", err)
@@ -307,7 +309,7 @@ func extractOwnerRepo(htmlURL string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func interactiveSelect(prs []pr.PRInfo) ([]pr.PRInfo, error) {
+func interactiveSelect(prs []pr.PRInfo) ([]pr.PRInfo, bool, error) {
 	var groups []pr.PRGroup
 	switch grouping {
 	case "dependency":
@@ -331,12 +333,12 @@ func interactiveSelect(prs []pr.PRInfo) ([]pr.PRInfo, error) {
 
 	idx, _, err := prompt.Run()
 	if err != nil {
-		return nil, fmt.Errorf("selection cancelled: %w", err)
+		return nil, false, fmt.Errorf("selection cancelled: %w", err)
 	}
 
 	if idx == 0 {
-		return prs, nil
+		return prs, false, nil
 	}
 
-	return groups[idx-1].PRs, nil
+	return groups[idx-1].PRs, true, nil
 }

--- a/internal/pr/grouping.go
+++ b/internal/pr/grouping.go
@@ -51,9 +51,6 @@ func sortedGroups(groups map[string][]PRInfo) []PRGroup {
 		})
 	}
 	sort.Slice(result, func(i, j int) bool {
-		if result[i].Count != result[j].Count {
-			return result[i].Count > result[j].Count
-		}
 		return result[i].Key < result[j].Key
 	})
 	return result

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -12,33 +12,49 @@ const (
 	colStatus = 30
 )
 
+type InfoFunc func(PRInfo) string
+
+func RepoInfoFunc(p PRInfo) string {
+	return fmt.Sprintf("%s/%s", p.Owner, p.Repo)
+}
+
+func DependencyInfoFunc(p PRInfo) string {
+	dep := ExtractDependencyName(p.Title)
+	if dep == "" {
+		return p.Title
+	}
+	return dep
+}
+
 func MakeHyperlink(text, url string) string {
 	return fmt.Sprintf("\033]8;;%s\033\\%s\033]8;;\033\\", url, text)
 }
 
-func PrintTableHeader(w *os.File) {
-	header := fmt.Sprintf("%-*s %-*s %-*s", colPR, "PR", colInfo, "Repository", colStatus, "Status")
+func PrintTableHeader(w *os.File, infoLabel string) {
+	header := fmt.Sprintf("%-*s %-*s %-*s", colPR, "PR", colInfo, infoLabel, colStatus, "Status")
 	divider := strings.Repeat("-", colPR+colInfo+colStatus+2)
 	_, _ = fmt.Fprintln(w, header)
 	_, _ = fmt.Fprintln(w, divider)
 }
 
-func UpdateTable(w *os.File, entries []StatusEntry) {
+func PrintRow(w *os.File, e StatusEntry, infoFn InfoFunc) {
+	prLabel := fmt.Sprintf("%-*s", colPR, fmt.Sprintf("#%d", e.PR.Number))
+	prLink := MakeHyperlink(prLabel, e.PR.URL)
+	info := infoFn(e.PR)
+	statusStr := colorizeStatus(e.State, e.Detail)
+	_, _ = fmt.Fprintf(w, "\033[2K%s %-*s %s\n", prLink, colInfo, truncate(info, colInfo), statusStr)
+}
+
+func UpdateTable(w *os.File, entries []StatusEntry, infoLabel string, infoFn InfoFunc) {
 	lineCount := len(entries) + 2 // +2 for header and divider
 
 	// Move cursor up to overwrite the table
 	_, _ = fmt.Fprintf(w, "\033[%dA", lineCount)
 
-	PrintTableHeader(w)
+	PrintTableHeader(w, infoLabel)
 
 	for _, e := range entries {
-		prLabel := fmt.Sprintf("#%d", e.PR.Number)
-		prLink := MakeHyperlink(prLabel, e.PR.URL)
-		repoName := fmt.Sprintf("%s/%s", e.PR.Owner, e.PR.Repo)
-
-		statusStr := colorizeStatus(e.State, e.Detail)
-
-		_, _ = fmt.Fprintf(w, "\033[2K%-*s %-*s %s\n", colPR, prLink, colInfo, truncate(repoName, colInfo), statusStr)
+		PrintRow(w, e, infoFn)
 	}
 }
 

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -186,17 +187,23 @@ func (p *Processor) merge(ctx context.Context, info pr.PRInfo, pullReq *github.P
 	})
 	if err != nil {
 		errMsg := err.Error()
-		if strings.Contains(errMsg, "405") || strings.Contains(errMsg, "not allowed") {
-			status.Update(idx, pr.StatusFailed, "merge not allowed")
-		} else if strings.Contains(errMsg, "409") || strings.Contains(errMsg, "conflict") {
+		if strings.Contains(errMsg, "409") || strings.Contains(errMsg, "conflict") {
 			status.Update(idx, pr.StatusConflict, "merge conflict")
 		} else {
-			status.Update(idx, pr.StatusFailed, fmt.Sprintf("merge error: %v", err))
+			status.Update(idx, pr.StatusFailed, mergeFailureDetail(err))
 		}
 		return
 	}
 
 	status.Update(idx, pr.StatusMerged, method)
+}
+
+func mergeFailureDetail(err error) string {
+	var ghErr *github.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Message != "" {
+		return ghErr.Message
+	}
+	return fmt.Sprintf("merge error: %v", err)
 }
 
 func determineMergeMethod(pullReq *github.PullRequest) string {


### PR DESCRIPTION
## Summary

- Show dependency name instead of repository in the table when a specific repo group is selected (avoids redundant info)
- Fix PR number column alignment broken by OSC 8 terminal hyperlink escape sequences
- Extract the actual GitHub API error message on merge failure instead of generic "merge not allowed"
- Sort group selection alphabetically by name instead of by PR count

## Test plan

- [ ] Run `marge`, select a specific repo, verify the table column shows "Dependency" with dependency names
- [ ] Run `marge`, select "All", verify the table column shows "Repository" as before
- [ ] Verify PR numbers are clickable hyperlinks with correct column alignment
- [ ] Trigger a merge failure and verify the detailed error message is shown


Made with [Cursor](https://cursor.com)