### PR TITLE
Add --merge-auto flag to sweep command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -159,7 +159,7 @@ func runOnce(ctx context.Context, client *github.Client, query string) error {
 		close(refreshStopped)
 	}
 
-	proc := process.NewProcessor(client, dryRun, login)
+	proc := process.NewProcessor(client, dryRun, false, login)
 
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 5)

--- a/cmd/sweep.go
+++ b/cmd/sweep.go
@@ -23,16 +23,18 @@ func init() {
 	sweepCmd.Flags().StringVar(&sweepAuthor, "author", "all", "Filter by PR author: \"renovate\", \"dependabot\", or \"all\"")
 	sweepCmd.Flags().StringVar(&sweepOrg, "org", "", "Limit to repos owned by this org or user (e.g. \"giantswarm\")")
 	sweepCmd.Flags().BoolVar(&sweepNoTUI, "no-tui", false, "Disable live table, print plain-text results instead")
+	sweepCmd.Flags().BoolVar(&sweepMergeAuto, "merge-auto", false, "Also merge PRs that have auto-merge enabled")
 
 	rootCmd.AddCommand(sweepCmd)
 }
 
 var (
-	sweepDryRun bool
-	sweepWatch  bool
-	sweepAuthor string
-	sweepOrg    string
-	sweepNoTUI  bool
+	sweepDryRun    bool
+	sweepWatch     bool
+	sweepAuthor    string
+	sweepOrg       string
+	sweepNoTUI     bool
+	sweepMergeAuto bool
 )
 
 var sweepCmd = &cobra.Command{
@@ -145,7 +147,7 @@ func sweepOnce(ctx context.Context, client *github.Client) error {
 		close(refreshStopped)
 	}
 
-	proc := process.NewProcessor(client, sweepDryRun, login)
+	proc := process.NewProcessor(client, sweepDryRun, sweepMergeAuto, login)
 
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 5)

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -17,13 +17,14 @@ const (
 )
 
 type Processor struct {
-	Client *github.Client
-	DryRun bool
-	Login  string
+	Client         *github.Client
+	DryRun         bool
+	MergeAutoMerge bool
+	Login          string
 }
 
-func NewProcessor(client *github.Client, dryRun bool, login string) *Processor {
-	return &Processor{Client: client, DryRun: dryRun, Login: login}
+func NewProcessor(client *github.Client, dryRun bool, mergeAutoMerge bool, login string) *Processor {
+	return &Processor{Client: client, DryRun: dryRun, MergeAutoMerge: mergeAutoMerge, Login: login}
 }
 
 func (p *Processor) ProcessPR(ctx context.Context, info pr.PRInfo, status *pr.PRStatus, idx int) {
@@ -61,7 +62,7 @@ func (p *Processor) ProcessPR(ctx context.Context, info pr.PRInfo, status *pr.PR
 		}
 	}
 
-	if pullReq.GetAutoMerge() != nil {
+	if pullReq.GetAutoMerge() != nil && !p.MergeAutoMerge {
 		status.Update(idx, pr.StatusAutoMerge, "auto-merge enabled")
 		return
 	}


### PR DESCRIPTION
## Summary

- Adds a `--merge-auto` flag to `marge sweep` that also merges PRs with auto-merge enabled on GitHub, instead of leaving them for the merge queue
- When the flag is not set, behavior is unchanged (auto-merge PRs are reported but not merged)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [ ] Run `marge sweep --merge-auto --dry-run` to verify the flag is recognized
- [ ] Run `marge sweep --merge-auto` against repos with auto-merge PRs to confirm they get merged


Made with [Cursor](https://cursor.com)