### PR TITLE
Add --org flag to default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ When run with a query (e.g. a repo name or dependency), it filters PRs directly 
 | `--watch` | `-w` | `false` | Keep polling for new PRs every 60 seconds |
 | `--grouping` | | `repo` | Group by `repo` or `dependency` |
 | `--author` | | `all` | Filter by PR author: `renovate`, `dependabot`, or `all` |
+| `--org` | | | Limit to repos owned by this org or user |
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,6 +22,7 @@ func init() {
 	runCmd.Flags().BoolVarP(&runOpts.Watch, "watch", "w", false, "Keep polling for new PRs (every 60s)")
 	runCmd.Flags().StringVar(&runOpts.Grouping, "grouping", "repo", "Group by \"repo\" or \"dependency\"")
 	runCmd.Flags().StringVar(&runOpts.Author, "author", "all", "Filter by PR author: \"renovate\", \"dependabot\", or \"all\"")
+	runCmd.Flags().StringVar(&runOpts.Org, "org", "", "Limit to repos owned by this org or user")
 	runCmd.Flags().BoolVar(&runOpts.NoTUI, "no-tui", false, "Disable live table, print plain-text results instead")
 	runCmd.Flags().StringVar(&runOpts.TrustedAuthors, "trusted-authors", "renovate[bot],dependabot[bot]", "Comma-separated list of trusted PR author logins")
 
@@ -62,6 +63,16 @@ optionally group them interactively, then approve and merge them.`,
 			prs, err := searchPRs(ctx, client, query, login, runOpts.Author)
 			if err != nil {
 				return fmt.Errorf("searching PRs: %w", err)
+			}
+
+			if runOpts.Org != "" {
+				filtered := prs[:0]
+				for _, p := range prs {
+					if strings.EqualFold(p.Owner, runOpts.Org) {
+						filtered = append(filtered, p)
+					}
+				}
+				prs = filtered
 			}
 
 			opts := runOpts


### PR DESCRIPTION
## Summary

- Add `--org` flag to the default `marge` command, matching the existing flag on `sweep`
- Filters PRs by org/user before the interactive group selection
- Update README flag table

## Test plan

- [x] `marge --org teemow` shows interactive selector with only teemow repos
- [x] `marge --help` lists the new `--org` flag

Made with [Cursor](https://cursor.com)