### PR TITLE
Auto-size table columns and sort PRs by repository

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,15 @@ func processOnce(ctx context.Context, client *github.Client, login string, prs [
 
 	fmt.Fprintf(os.Stderr, "Processing %d PR(s)...\n\n", len(prs))
 
+	sort.Slice(prs, func(i, j int) bool {
+		ri := prs[i].Owner + "/" + prs[i].Repo
+		rj := prs[j].Owner + "/" + prs[j].Repo
+		if ri != rj {
+			return ri < rj
+		}
+		return prs[i].Number < prs[j].Number
+	})
+
 	status := pr.NewPRStatus()
 	indices := make([]int, len(prs))
 	for i, p := range prs {
@@ -45,6 +55,7 @@ func processOnce(ctx context.Context, client *github.Client, login string, prs [
 	if cols == nil {
 		cols = pr.FullColumns()
 	}
+	pr.AdjustColumnWidths(cols, prs)
 
 	if !opts.NoTUI {
 		pr.PrintTableHeader(os.Stdout, cols)

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -183,6 +183,19 @@ func printPlainEntry(w *os.File, e StatusEntry) {
 		e.PR.Number, e.PR.Owner, e.PR.Repo, dep, verStr, e.PR.Author, detail)
 }
 
+// AdjustColumnWidths widens each column so every value fits without truncation.
+func AdjustColumnWidths(cols []TableColumn, prs []PRInfo) {
+	for i, c := range cols {
+		w := len(c.Label)
+		for _, p := range prs {
+			if v := len(c.Fn(p)); v > w {
+				w = v
+			}
+		}
+		cols[i].Width = w
+	}
+}
+
 func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s


### PR DESCRIPTION
## Summary
- Auto-size all table columns based on actual content so values like dependency names are never truncated with `...`
- Sort the PR table alphabetically by repository (owner/repo), with PRs within the same repo ordered by number

## Test plan
- [ ] Run `marge --org <org>` and verify the Dependency column shows full names
- [ ] Verify PRs are sorted alphabetically by repository in the table output

Made with [Cursor](https://cursor.com)