### PR TITLE
Fix title matching for grouped Renovate updates and generic conventional commit prefixes

### DIFF
--- a/internal/pr/parse.go
+++ b/internal/pr/parse.go
@@ -16,7 +16,7 @@ func ExtractOwnerRepo(htmlURL string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-var conventionalCommitPrefixRE = regexp.MustCompile(`(?i)^\w+\([^)]*deps[^)]*\):\s*`)
+var conventionalCommitPrefixRE = regexp.MustCompile(`(?i)^\w+(\([^)]*\))?:\s*`)
 
 func stripConventionalCommitPrefix(title string) string {
 	return conventionalCommitPrefixRE.ReplaceAllString(title, "")
@@ -45,6 +45,8 @@ var dependencyPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?i)^(lock file maintenance)$`),
 	// Renovate: "Update foo/bar to v1.2.3" (generic fallback, must be after specific patterns)
 	regexp.MustCompile(`(?i)^update ([@\w\-./]+(?:/[@\w\-./]+)*) to `),
+	// Renovate: grouped update "Update github-actions (major)" or "Update npm (minor)"
+	regexp.MustCompile(`(?i)^update ([@\w\-./]+(?:/[@\w\-./]+)*)\s+\((?:major|minor|patch|digest)\)\s*$`),
 	// Dependabot: "Bump foo from 1.2.3 to 1.2.4"
 	regexp.MustCompile(`(?i)bump ([@\w\-./]+(?:/[@\w\-./]+)*) from`),
 	// Dependabot: "Bump the foo group ..."

--- a/internal/pr/parse_test.go
+++ b/internal/pr/parse_test.go
@@ -237,6 +237,43 @@ func TestExtractDependencyName(t *testing.T) {
 			title: "Set package ecosystem to 'cargo' in dependabot config",
 			want:  "cargo",
 		},
+		// Renovate: grouped update without version
+		{
+			name:  "renovate grouped update major",
+			title: "Update github-actions (major)",
+			want:  "github-actions",
+		},
+		{
+			name:  "renovate grouped update minor",
+			title: "Update npm (minor)",
+			want:  "npm",
+		},
+		{
+			name:  "renovate grouped update patch",
+			title: "Update docker (patch)",
+			want:  "docker",
+		},
+		{
+			name:  "renovate grouped update digest",
+			title: "Update github-actions (digest)",
+			want:  "github-actions",
+		},
+		// Conventional commit prefix without deps scope
+		{
+			name:  "chore prefix configure renovate",
+			title: "chore: Configure Renovate",
+			want:  "Configure Renovate",
+		},
+		{
+			name:  "build prefix bump",
+			title: "build: Bump lodash from 4.17.20 to 4.17.21",
+			want:  "lodash",
+		},
+		{
+			name:  "chore(ci) prefix configure renovate",
+			title: "chore(ci): Configure Renovate",
+			want:  "Configure Renovate",
+		},
 		// Edge cases
 		{
 			name:  "empty title",
@@ -391,6 +428,23 @@ func TestIsDependencyUpdateTitle(t *testing.T) {
 		{
 			name:  "dependabot set package ecosystem",
 			title: "Set package ecosystem to 'gomod' in dependabot config",
+			want:  true,
+		},
+		// Renovate grouped updates
+		{
+			name:  "renovate grouped update major",
+			title: "Update github-actions (major)",
+			want:  true,
+		},
+		{
+			name:  "renovate grouped update minor",
+			title: "Update npm (minor)",
+			want:  true,
+		},
+		// Conventional commit prefix without deps scope
+		{
+			name:  "chore prefix configure renovate",
+			title: "chore: Configure Renovate",
 			want:  true,
 		},
 		// Non-dependency PRs


### PR DESCRIPTION
## Summary

- Add regex pattern for Renovate grouped update titles like "Update github-actions (major)" that use an update-type suffix instead of a target version.
- Broaden `stripConventionalCommitPrefix` to strip any conventional commit prefix (e.g. `chore:`, `build:`, `chore(ci):`), not just `(deps)` scopes. This fixes titles like "chore: Configure Renovate" that were missed because the prefix wasn't stripped before matching the `^(configure renovate)$` pattern.
- Add test coverage for both scenarios.

## Test plan

- [x] All existing tests pass
- [x] New tests cover grouped update titles (major, minor, patch, digest)
- [x] New tests cover conventional commit prefixes without deps scope

Made with [Cursor](https://cursor.com)