### PR TITLE
Distinguish security scan failures from other CI failures (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When run with a query (e.g. a repo name or dependency), it filters PRs directly 
 | `--org` | | | Limit to repos owned by this org or user |
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
-| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list |
+| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list. The built-in list covers `govulncheck`, `trivy`, `codeql`, `snyk`, `gosec`, `gitleaks`, `semgrep`, `checkov`, `kics`, `vulnerability/vulnerabilities`, `sast`, `dast`, `dependency-review`, and any check whose name contains `security`. If your CodeQL job is named `Analyze (<lang>)` (the github/codeql-action template default), add `Analyze` to this flag so it gets caught. |
 
 ### `marge sweep [flags]`
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ When run with a query (e.g. a repo name or dependency), it filters PRs directly 
 | `--org` | | | Limit to repos owned by this org or user |
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
+| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list |
 
 ### `marge sweep [flags]`
 
-Processes all matching PRs without interactive grouping. After processing, prints an **Action required** section listing any PRs that failed, have conflicts, or came from untrusted authors.
+Processes all matching PRs without interactive grouping. After processing, prints a **Security failures** section followed by an **Action required** section listing any PRs that failed, have conflicts, or came from untrusted authors. Security failures (e.g. govulncheck, Trivy, CodeQL) are separated so they are not mistaken for ordinary CI flakiness.
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
@@ -88,6 +89,7 @@ Processes all matching PRs without interactive grouping. After processing, print
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--merge-auto` | | `false` | Also merge PRs that have auto-merge enabled (by default these are skipped) |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
+| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list |
 
 ### Other commands
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,15 @@ When run with a query (e.g. a repo name or dependency), it filters PRs directly 
 | `--org` | | | Limit to repos owned by this org or user |
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
-| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list. The built-in list covers `govulncheck`, `trivy`, `codeql`, `snyk`, `gosec`, `gitleaks`, `semgrep`, `checkov`, `kics`, `vulnerability/vulnerabilities`, `sast`, `dast`, `dependency-review`, and any check whose name contains `security`. If your CodeQL job is named `Analyze (<lang>)` (the github/codeql-action template default), add `Analyze` to this flag so it gets caught. |
+| `--security-patterns` | | _(built-in)_ | Override the built-in security check pattern list (see below) |
+
+#### Security check patterns
+
+When a PR's CI fails, marge classifies the failure as security-related if any failing check's name contains one of the configured substrings (case-insensitive). Security failures are surfaced separately so they are not mistaken for ordinary build/test flakiness.
+
+The built-in list contains: `security`, `govulncheck`, `trivy`, `codeql`, `snyk`, `gosec`, `gitleaks`, `semgrep`, `checkov`, `kics`, `vulnerability`, `vulnerabilities`, `sast`, `dast`, `dependency-review`, `dependency review`.
+
+Pass `--security-patterns "Trivy,Govulncheck,CodeQL,Analyze"` to replace the list. The github/codeql-action template uses a job name like `Analyze (<lang>)` that the `codeql` substring will not match, so add `Analyze` if you rely on that template.
 
 ### `marge sweep [flags]`
 
@@ -89,7 +97,7 @@ Processes all matching PRs without interactive grouping. After processing, print
 | `--no-tui` | | `false` | Disable the live table; print plain-text results instead |
 | `--merge-auto` | | `false` | Also merge PRs that have auto-merge enabled (by default these are skipped) |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
-| `--security-patterns` | | _(built-in)_ | Comma-separated case-insensitive substrings used to flag failing CI checks as security-related (e.g. `Trivy,Govulncheck,CodeQL`). When set, overrides the built-in list |
+| `--security-patterns` | | _(built-in)_ | Override the built-in security check pattern list (see [Security check patterns](#security-check-patterns)) |
 
 ### Other commands
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -30,11 +30,6 @@ type RunOptions struct {
 	OnComplete       func(*pr.PRStatus)
 }
 
-func processOnce(ctx context.Context, client *github.Client, login string, prs []pr.PRInfo, opts RunOptions) error {
-	_, err := processOnceWithStatus(ctx, client, login, prs, opts)
-	return err
-}
-
 func processOnceWithStatus(ctx context.Context, client *github.Client, login string, prs []pr.PRInfo, opts RunOptions) (*pr.PRStatus, error) {
 	if len(prs) == 0 {
 		fmt.Fprintln(os.Stderr, "No matching PRs found.")
@@ -94,9 +89,7 @@ func processOnceWithStatus(ctx context.Context, client *github.Client, login str
 	}
 
 	proc := process.NewProcessor(client, opts.DryRun, opts.MergeAuto, login, parseTrustedAuthors(opts.TrustedAuthors))
-	if patterns, ok := parseSecurityPatterns(opts.SecurityPatterns); ok {
-		proc.SecurityCheckPatterns = patterns
-	}
+	proc.SecurityCheckPatterns = parseCSVList(opts.SecurityPatterns)
 
 	// Build a per-repo index so we can look up each PR's status table index.
 	indexByPR := make(map[string]int, len(prs))
@@ -167,30 +160,28 @@ func watchLoop(ctx context.Context, watch bool, fn func(ctx context.Context) err
 	}
 }
 
-func parseTrustedAuthors(csv string) map[string]bool {
-	m := make(map[string]bool)
-	for _, a := range strings.Split(csv, ",") {
-		a = strings.TrimSpace(a)
-		if a != "" {
-			m[a] = true
-		}
+// parseCSVList splits a comma-separated string into trimmed, non-empty
+// entries. It returns nil when the input has no usable entries so callers
+// can distinguish "user did not configure this" from "user configured an
+// explicit list".
+func parseCSVList(csv string) []string {
+	if strings.TrimSpace(csv) == "" {
+		return nil
 	}
-	return m
-}
-
-// parseSecurityPatterns splits a comma-separated list of security check
-// name patterns. The boolean return is false when the caller did not set
-// the flag (empty string), so the processor keeps its default list.
-func parseSecurityPatterns(csv string) ([]string, bool) {
-	csv = strings.TrimSpace(csv)
-	if csv == "" {
-		return nil, false
-	}
-	var patterns []string
+	var out []string
 	for _, p := range strings.Split(csv, ",") {
 		if p = strings.TrimSpace(p); p != "" {
-			patterns = append(patterns, p)
+			out = append(out, p)
 		}
 	}
-	return patterns, true
+	return out
+}
+
+func parseTrustedAuthors(csv string) map[string]bool {
+	entries := parseCSVList(csv)
+	m := make(map[string]bool, len(entries))
+	for _, a := range entries {
+		m[a] = true
+	}
+	return m
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -60,6 +60,9 @@ func processOnceWithStatus(ctx context.Context, client *github.Client, login str
 	pr.AdjustColumnWidths(cols, prs)
 
 	if !opts.NoTUI {
+		pr.DisableLineWrap(os.Stdout)
+		defer pr.EnableLineWrap(os.Stdout)
+
 		pr.PrintTableHeader(os.Stdout, cols)
 		for _, e := range status.Snapshot() {
 			pr.PrintRow(os.Stdout, e, cols)
@@ -129,6 +132,10 @@ func processOnceWithStatus(ctx context.Context, client *github.Client, login str
 		pr.PrintPlainResults(os.Stdout, status)
 	} else {
 		pr.UpdateTable(os.Stdout, status.Snapshot(), cols)
+		// Restore wrapping before any post-table prose so long lines
+		// (e.g. failure URLs in the summary) are not clipped by the
+		// disabled-wrap mode that protected the table redraws.
+		pr.EnableLineWrap(os.Stdout)
 	}
 
 	fmt.Fprintf(os.Stderr, "\n%s\n", status.FormatSummary())

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -16,17 +16,18 @@ import (
 
 // RunOptions holds the configuration shared between the run and sweep commands.
 type RunOptions struct {
-	DryRun         bool
-	Watch          bool
-	NoTUI          bool
-	Author         string
-	TrustedAuthors string
-	MergeAuto      bool
-	Org            string
-	ReposFile      string
-	Grouping       string
-	Cols           []pr.TableColumn
-	OnComplete     func(*pr.PRStatus)
+	DryRun           bool
+	Watch            bool
+	NoTUI            bool
+	Author           string
+	TrustedAuthors   string
+	MergeAuto        bool
+	Org              string
+	ReposFile        string
+	Grouping         string
+	SecurityPatterns string
+	Cols             []pr.TableColumn
+	OnComplete       func(*pr.PRStatus)
 }
 
 func processOnce(ctx context.Context, client *github.Client, login string, prs []pr.PRInfo, opts RunOptions) error {
@@ -93,6 +94,9 @@ func processOnceWithStatus(ctx context.Context, client *github.Client, login str
 	}
 
 	proc := process.NewProcessor(client, opts.DryRun, opts.MergeAuto, login, parseTrustedAuthors(opts.TrustedAuthors))
+	if patterns, ok := parseSecurityPatterns(opts.SecurityPatterns); ok {
+		proc.SecurityCheckPatterns = patterns
+	}
 
 	// Build a per-repo index so we can look up each PR's status table index.
 	indexByPR := make(map[string]int, len(prs))
@@ -172,4 +176,21 @@ func parseTrustedAuthors(csv string) map[string]bool {
 		}
 	}
 	return m
+}
+
+// parseSecurityPatterns splits a comma-separated list of security check
+// name patterns. The boolean return is false when the caller did not set
+// the flag (empty string), so the processor keeps its default list.
+func parseSecurityPatterns(csv string) ([]string, bool) {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil, false
+	}
+	var patterns []string
+	for _, p := range strings.Split(csv, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			patterns = append(patterns, p)
+		}
+	}
+	return patterns, true
 }

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -5,28 +5,25 @@ import (
 	"testing"
 )
 
-func TestParseSecurityPatterns(t *testing.T) {
+func TestParseCSVList(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    []string
-		wantSet bool
+		name  string
+		input string
+		want  []string
 	}{
-		{"empty string is unset", "", nil, false},
-		{"whitespace only is unset", "   ", nil, false},
-		{"single pattern", "trivy", []string{"trivy"}, true},
-		{"multiple patterns", "Trivy, govulncheck ,CodeQL", []string{"Trivy", "govulncheck", "CodeQL"}, true},
-		{"empty entries are skipped", "trivy,,gosec, ", []string{"trivy", "gosec"}, true},
+		{"empty string is nil", "", nil},
+		{"whitespace only is nil", "   ", nil},
+		{"single pattern", "trivy", []string{"trivy"}},
+		{"multiple patterns", "Trivy, govulncheck ,CodeQL", []string{"Trivy", "govulncheck", "CodeQL"}},
+		{"empty entries are skipped", "trivy,,gosec, ", []string{"trivy", "gosec"}},
+		{"only separators yields nil", ",, ,", nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, ok := parseSecurityPatterns(tt.input)
-			if ok != tt.wantSet {
-				t.Errorf("parseSecurityPatterns(%q) ok=%v, want %v", tt.input, ok, tt.wantSet)
-			}
+			got := parseCSVList(tt.input)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseSecurityPatterns(%q) = %v, want %v", tt.input, got, tt.want)
+				t.Errorf("parseCSVList(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSecurityPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantSet bool
+	}{
+		{"empty string is unset", "", nil, false},
+		{"whitespace only is unset", "   ", nil, false},
+		{"single pattern", "trivy", []string{"trivy"}, true},
+		{"multiple patterns", "Trivy, govulncheck ,CodeQL", []string{"Trivy", "govulncheck", "CodeQL"}, true},
+		{"empty entries are skipped", "trivy,,gosec, ", []string{"trivy", "gosec"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseSecurityPatterns(tt.input)
+			if ok != tt.wantSet {
+				t.Errorf("parseSecurityPatterns(%q) ok=%v, want %v", tt.input, ok, tt.wantSet)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseSecurityPatterns(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTrustedAuthors(t *testing.T) {
+	got := parseTrustedAuthors("renovate[bot], dependabot[bot] , ,custom[bot]")
+	want := map[string]bool{
+		"renovate[bot]":   true,
+		"dependabot[bot]": true,
+		"custom[bot]":     true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseTrustedAuthors = %v, want %v", got, want)
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,6 +28,7 @@ func init() {
 	runCmd.Flags().BoolVar(&runOpts.NoTUI, "no-tui", false, "Disable live table, print plain-text results instead")
 	runCmd.Flags().BoolVar(&runOpts.MergeAuto, "merge-auto", false, "Also merge PRs that have auto-merge enabled")
 	runCmd.Flags().StringVar(&runOpts.TrustedAuthors, "trusted-authors", "renovate[bot],dependabot[bot]", "Comma-separated list of trusted PR author logins")
+	runCmd.Flags().StringVar(&runOpts.SecurityPatterns, "security-patterns", "", "Comma-separated list of case-insensitive substrings used to flag failing CI checks as security-related (defaults to a built-in list)")
 
 	rootCmd.AddCommand(runCmd)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -104,7 +104,8 @@ optionally group them interactively, then approve and merge them.`,
 				}
 			}
 
-			return processOnce(ctx, client, login, prs, opts)
+			_, err = processOnceWithStatus(ctx, client, login, prs, opts)
+			return err
 		})
 	},
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -58,6 +58,9 @@ returning structured JSON results instead of terminal output.`,
 				mcp.WithString("trusted_authors",
 					mcp.Description("Comma-separated list of trusted PR author logins (default: \"renovate[bot],dependabot[bot]\")"),
 				),
+				mcp.WithString("security_patterns",
+					mcp.Description("Comma-separated list of case-insensitive substrings used to flag failing CI checks as security-related (defaults to a built-in list)"),
+				),
 			),
 			handleSweep,
 		)
@@ -68,18 +71,20 @@ returning structured JSON results instead of terminal output.`,
 
 // SweepResult is the structured JSON output returned by the sweep MCP tool.
 type SweepResult struct {
-	Summary        SweepSummary   `json:"summary"`
-	Merged         []SweepPREntry `json:"merged,omitempty"`
-	ActionRequired []SweepPREntry `json:"action_required,omitempty"`
-	Skipped        []SweepPREntry `json:"skipped,omitempty"`
+	Summary          SweepSummary   `json:"summary"`
+	Merged           []SweepPREntry `json:"merged,omitempty"`
+	SecurityFailures []SweepPREntry `json:"security_failures,omitempty"`
+	ActionRequired   []SweepPREntry `json:"action_required,omitempty"`
+	Skipped          []SweepPREntry `json:"skipped,omitempty"`
 }
 
 // SweepSummary contains aggregate counts from the sweep.
 type SweepSummary struct {
-	Total   int `json:"total"`
-	Merged  int `json:"merged"`
-	Failed  int `json:"failed"`
-	Skipped int `json:"skipped"`
+	Total            int `json:"total"`
+	Merged           int `json:"merged"`
+	Failed           int `json:"failed"`
+	SecurityFailures int `json:"security_failures"`
+	Skipped          int `json:"skipped"`
 }
 
 // SweepPREntry represents a single PR in the sweep results.
@@ -101,6 +106,7 @@ func handleSweep(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToo
 	dryRun := request.GetBool("dry_run", false)
 	author := request.GetString("author", "all")
 	trustedAuthors := request.GetString("trusted_authors", "renovate[bot],dependabot[bot]")
+	securityPatterns := request.GetString("security_patterns", "")
 	reposParam := request.GetStringSlice("repos", nil)
 
 	// Create a temporary repos file if repos array was provided.
@@ -139,11 +145,12 @@ func handleSweep(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToo
 	}
 
 	opts := RunOptions{
-		DryRun:         dryRun,
-		MergeAuto:      mergeAuto,
-		NoTUI:          true,
-		Author:         author,
-		TrustedAuthors: trustedAuthors,
+		DryRun:           dryRun,
+		MergeAuto:        mergeAuto,
+		NoTUI:            true,
+		Author:           author,
+		TrustedAuthors:   trustedAuthors,
+		SecurityPatterns: securityPatterns,
 	}
 
 	status, err := processOnceWithStatus(ctx, client, login, prs, opts)
@@ -164,18 +171,20 @@ func handleSweep(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToo
 func buildSweepResult(status *pr.PRStatus) SweepResult {
 	merged, failed, skipped := status.Summary()
 	total := status.Len()
+	securityEntries := status.SecurityFailedEntries()
 
 	result := SweepResult{
 		Summary: SweepSummary{
-			Total:   total,
-			Merged:  merged,
-			Failed:  failed,
-			Skipped: skipped,
+			Total:            total,
+			Merged:           merged,
+			Failed:           failed,
+			SecurityFailures: len(securityEntries),
+			Skipped:          skipped,
 		},
 	}
 
-	for _, e := range status.MergedEntries() {
-		result.Merged = append(result.Merged, SweepPREntry{
+	toEntry := func(e pr.StatusEntry) SweepPREntry {
+		return SweepPREntry{
 			Owner:  e.PR.Owner,
 			Repo:   e.PR.Repo,
 			Number: e.PR.Number,
@@ -183,31 +192,26 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 			URL:    e.PR.URL,
 			Status: e.State.String(),
 			Detail: e.Detail,
-		})
+		}
+	}
+
+	for _, e := range status.MergedEntries() {
+		result.Merged = append(result.Merged, toEntry(e))
+	}
+
+	for _, e := range securityEntries {
+		result.SecurityFailures = append(result.SecurityFailures, toEntry(e))
 	}
 
 	for _, e := range status.ActionRequired() {
-		result.ActionRequired = append(result.ActionRequired, SweepPREntry{
-			Owner:  e.PR.Owner,
-			Repo:   e.PR.Repo,
-			Number: e.PR.Number,
-			Title:  e.PR.Title,
-			URL:    e.PR.URL,
-			Status: e.State.String(),
-			Detail: e.Detail,
-		})
+		if e.State == pr.StatusFailedSecurity {
+			continue
+		}
+		result.ActionRequired = append(result.ActionRequired, toEntry(e))
 	}
 
 	for _, e := range status.SkippedEntries() {
-		result.Skipped = append(result.Skipped, SweepPREntry{
-			Owner:  e.PR.Owner,
-			Repo:   e.PR.Repo,
-			Number: e.PR.Number,
-			Title:  e.PR.Title,
-			URL:    e.PR.URL,
-			Status: e.State.String(),
-			Detail: e.Detail,
-		})
+		result.Skipped = append(result.Skipped, toEntry(e))
 	}
 
 	return result

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -79,6 +79,11 @@ type SweepResult struct {
 }
 
 // SweepSummary contains aggregate counts from the sweep.
+//
+// Failed and SecurityFailures are disjoint: Failed counts only the
+// non-security failure entries, so consumers can use
+// Failed + SecurityFailures to get the total number of action-required
+// PRs without double-counting.
 type SweepSummary struct {
 	Total            int `json:"total"`
 	Merged           int `json:"merged"`
@@ -177,7 +182,7 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 		Summary: SweepSummary{
 			Total:            total,
 			Merged:           merged,
-			Failed:           failed,
+			Failed:           failed - len(securityEntries),
 			SecurityFailures: len(securityEntries),
 			Skipped:          skipped,
 		},

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/teemow/marge/internal/pr"
+)
+
+// TestBuildSweepResult_failedAndSecurityAreDisjoint guards the contract
+// documented on SweepSummary: a security failure must be counted in
+// SecurityFailures and not in Failed, so consumers can sum them without
+// double-counting.
+func TestBuildSweepResult_failedAndSecurityAreDisjoint(t *testing.T) {
+	status := pr.NewPRStatus()
+	idx1 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 1})
+	status.Update(idx1, pr.StatusFailed, "checks failed")
+	idx2 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 2})
+	status.Update(idx2, pr.StatusFailedSecurity, "security check failed: trivy")
+	idx3 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 3})
+	status.Update(idx3, pr.StatusMerged, "squash")
+	idx4 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 4})
+	status.Update(idx4, pr.StatusSkipped, "dry-run")
+
+	got := buildSweepResult(status)
+
+	if got.Summary.Total != 4 {
+		t.Errorf("Total = %d, want 4", got.Summary.Total)
+	}
+	if got.Summary.Merged != 1 {
+		t.Errorf("Merged = %d, want 1", got.Summary.Merged)
+	}
+	if got.Summary.Failed != 1 {
+		t.Errorf("Failed = %d, want 1 (security failures must be excluded)", got.Summary.Failed)
+	}
+	if got.Summary.SecurityFailures != 1 {
+		t.Errorf("SecurityFailures = %d, want 1", got.Summary.SecurityFailures)
+	}
+	if got.Summary.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", got.Summary.Skipped)
+	}
+
+	if len(got.SecurityFailures) != 1 {
+		t.Fatalf("SecurityFailures slice len = %d, want 1", len(got.SecurityFailures))
+	}
+	if got.SecurityFailures[0].Number != 2 {
+		t.Errorf("SecurityFailures[0].Number = %d, want 2", got.SecurityFailures[0].Number)
+	}
+
+	if len(got.ActionRequired) != 1 {
+		t.Fatalf("ActionRequired slice len = %d, want 1", len(got.ActionRequired))
+	}
+	if got.ActionRequired[0].Number != 1 {
+		t.Errorf("ActionRequired[0].Number = %d, want 1", got.ActionRequired[0].Number)
+	}
+}

--- a/cmd/sweep.go
+++ b/cmd/sweep.go
@@ -24,6 +24,7 @@ func init() {
 	sweepCmd.Flags().BoolVar(&sweepOpts.NoTUI, "no-tui", false, "Disable live table, print plain-text results instead")
 	sweepCmd.Flags().BoolVar(&sweepOpts.MergeAuto, "merge-auto", false, "Also merge PRs that have auto-merge enabled")
 	sweepCmd.Flags().StringVar(&sweepOpts.TrustedAuthors, "trusted-authors", "renovate[bot],dependabot[bot]", "Comma-separated list of trusted PR author logins")
+	sweepCmd.Flags().StringVar(&sweepOpts.SecurityPatterns, "security-patterns", "", "Comma-separated list of case-insensitive substrings used to flag failing CI checks as security-related (defaults to a built-in list)")
 
 	rootCmd.AddCommand(sweepCmd)
 }
@@ -70,9 +71,31 @@ that could not be merged so you can fix them manually.`,
 			if !opts.NoTUI {
 				opts.OnComplete = func(status *pr.PRStatus) {
 					actionRequired := status.ActionRequired()
-					if len(actionRequired) > 0 {
-						fmt.Fprintf(os.Stderr, "\nAction required (%d):\n\n", len(actionRequired))
-						for _, e := range actionRequired {
+					if len(actionRequired) == 0 {
+						return
+					}
+
+					var securityFailed, otherFailed []pr.StatusEntry
+					for _, e := range actionRequired {
+						if e.State == pr.StatusFailedSecurity {
+							securityFailed = append(securityFailed, e)
+						} else {
+							otherFailed = append(otherFailed, e)
+						}
+					}
+
+					if len(securityFailed) > 0 {
+						fmt.Fprintf(os.Stderr, "\nSecurity failures (%d):\n\n", len(securityFailed))
+						for _, e := range securityFailed {
+							fmt.Fprintf(os.Stderr, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
+							fmt.Fprintf(os.Stderr, "         %s\n", e.PR.Title)
+							fmt.Fprintf(os.Stderr, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
+						}
+					}
+
+					if len(otherFailed) > 0 {
+						fmt.Fprintf(os.Stderr, "\nAction required (%d):\n\n", len(otherFailed))
+						for _, e := range otherFailed {
 							fmt.Fprintf(os.Stderr, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
 							fmt.Fprintf(os.Stderr, "         %s\n", e.PR.Title)
 							fmt.Fprintf(os.Stderr, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))

--- a/cmd/sweep.go
+++ b/cmd/sweep.go
@@ -70,41 +70,30 @@ that could not be merged so you can fix them manually.`,
 			opts := sweepOpts
 			if !opts.NoTUI {
 				opts.OnComplete = func(status *pr.PRStatus) {
-					actionRequired := status.ActionRequired()
-					if len(actionRequired) == 0 {
-						return
-					}
-
-					var securityFailed, otherFailed []pr.StatusEntry
-					for _, e := range actionRequired {
-						if e.State == pr.StatusFailedSecurity {
-							securityFailed = append(securityFailed, e)
-						} else {
-							otherFailed = append(otherFailed, e)
-						}
-					}
-
-					if len(securityFailed) > 0 {
-						fmt.Fprintf(os.Stderr, "\nSecurity failures (%d):\n\n", len(securityFailed))
-						for _, e := range securityFailed {
-							fmt.Fprintf(os.Stderr, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
-							fmt.Fprintf(os.Stderr, "         %s\n", e.PR.Title)
-							fmt.Fprintf(os.Stderr, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
-						}
-					}
-
-					if len(otherFailed) > 0 {
-						fmt.Fprintf(os.Stderr, "\nAction required (%d):\n\n", len(otherFailed))
-						for _, e := range otherFailed {
-							fmt.Fprintf(os.Stderr, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
-							fmt.Fprintf(os.Stderr, "         %s\n", e.PR.Title)
-							fmt.Fprintf(os.Stderr, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
-						}
-					}
+					security, other := pr.SplitActionRequired(status.ActionRequired())
+					printSweepFailures(os.Stderr, "Security failures", security)
+					printSweepFailures(os.Stderr, "Action required", other)
 				}
 			}
 
-			return processOnce(ctx, client, login, prs, opts)
+			_, err = processOnceWithStatus(ctx, client, login, prs, opts)
+			return err
 		})
 	},
+}
+
+// printSweepFailures emits a header and one stanza per failure entry,
+// formatted for the TUI summary that follows the live table. It is a
+// no-op for empty groups, so callers can pass either failure bucket
+// without guarding.
+func printSweepFailures(w *os.File, header string, entries []pr.StatusEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\n%s (%d):\n\n", header, len(entries))
+	for _, e := range entries {
+		_, _ = fmt.Fprintf(w, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
+		_, _ = fmt.Fprintf(w, "         %s\n", e.PR.Title)
+		_, _ = fmt.Fprintf(w, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
+	}
 }

--- a/internal/pr/status.go
+++ b/internal/pr/status.go
@@ -166,6 +166,19 @@ func (s *PRStatus) SecurityFailedEntries() []StatusEntry {
 	return result
 }
 
+// SplitActionRequired partitions the action-required list into security
+// failures and everything else, preserving the input order in each group.
+func SplitActionRequired(entries []StatusEntry) (security, other []StatusEntry) {
+	for _, e := range entries {
+		if e.State == StatusFailedSecurity {
+			security = append(security, e)
+		} else {
+			other = append(other, e)
+		}
+	}
+	return
+}
+
 func (s *PRStatus) MergedEntries() []StatusEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/pr/status.go
+++ b/internal/pr/status.go
@@ -17,6 +17,7 @@ const (
 	StatusAlreadyMerged
 	StatusAutoMerge
 	StatusFailed
+	StatusFailedSecurity
 	StatusSkipped
 	StatusConflict
 	StatusUntrustedAuthor
@@ -42,6 +43,8 @@ func (s StatusState) String() string {
 		return "Auto-merge"
 	case StatusFailed:
 		return "Failed"
+	case StatusFailedSecurity:
+		return "Failed (security)"
 	case StatusSkipped:
 		return "Skipped"
 	case StatusConflict:
@@ -103,7 +106,7 @@ func (s *PRStatus) Summary() (merged, failed, skipped int) {
 		switch e.State {
 		case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
 			merged++
-		case StatusFailed, StatusConflict, StatusUntrustedAuthor:
+		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
 			failed++
 		case StatusSkipped:
 			skipped++
@@ -126,7 +129,7 @@ func (s *PRStatus) FormatSummary() string {
 		switch e.State {
 		case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
 			merged++
-		case StatusFailed, StatusConflict, StatusUntrustedAuthor:
+		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
 			failed++
 		case StatusSkipped:
 			skipped++
@@ -142,7 +145,21 @@ func (s *PRStatus) ActionRequired() []StatusEntry {
 	var result []StatusEntry
 	for _, e := range s.entries {
 		switch e.State {
-		case StatusFailed, StatusConflict, StatusUntrustedAuthor:
+		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// SecurityFailedEntries returns entries that failed specifically because a
+// security-related check reported a problem.
+func (s *PRStatus) SecurityFailedEntries() []StatusEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []StatusEntry
+	for _, e := range s.entries {
+		if e.State == StatusFailedSecurity {
 			result = append(result, e)
 		}
 	}

--- a/internal/pr/status_test.go
+++ b/internal/pr/status_test.go
@@ -1,0 +1,57 @@
+package pr
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStatusFailedSecurity_string(t *testing.T) {
+	if got := StatusFailedSecurity.String(); got != "Failed (security)" {
+		t.Errorf("StatusFailedSecurity.String() = %q, want %q", got, "Failed (security)")
+	}
+}
+
+func TestStatus_securityFailureCountedAsFailed(t *testing.T) {
+	s := NewPRStatus()
+	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 1})
+	s.Update(idx, StatusFailedSecurity, "security check failed: govulncheck")
+
+	merged, failed, skipped := s.Summary()
+	if failed != 1 {
+		t.Errorf("Summary failed = %d, want 1", failed)
+	}
+	if merged != 0 || skipped != 0 {
+		t.Errorf("Summary merged=%d skipped=%d, want zero", merged, skipped)
+	}
+}
+
+func TestStatus_securityFailureInActionRequired(t *testing.T) {
+	s := NewPRStatus()
+	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 7})
+	s.Update(idx, StatusFailedSecurity, "security check failed: trivy")
+
+	ar := s.ActionRequired()
+	if len(ar) != 1 {
+		t.Fatalf("ActionRequired len = %d, want 1", len(ar))
+	}
+	if ar[0].State != StatusFailedSecurity {
+		t.Errorf("entry state = %v, want StatusFailedSecurity", ar[0].State)
+	}
+
+	sec := s.SecurityFailedEntries()
+	if len(sec) != 1 {
+		t.Fatalf("SecurityFailedEntries len = %d, want 1", len(sec))
+	}
+}
+
+func TestColorizeStatus_securityIsDistinct(t *testing.T) {
+	regular := ColorizeStatus(StatusFailed, "checks failed")
+	security := ColorizeStatus(StatusFailedSecurity, "govulncheck")
+
+	if regular == security {
+		t.Fatal("ColorizeStatus for StatusFailed and StatusFailedSecurity must differ")
+	}
+	if !strings.Contains(security, "security") {
+		t.Errorf("security colorize output %q should contain the word 'security'", security)
+	}
+}

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -114,6 +114,23 @@ func UpdateTable(w *os.File, entries []StatusEntry, cols []TableColumn) {
 	}
 }
 
+// DisableLineWrap turns off the terminal's auto-wrap (DECAWM) so rows
+// wider than the terminal are clipped at the right edge instead of
+// wrapping onto a second physical line. UpdateTable's cursor-up math
+// counts logical rows, so a wrapped row would desync the redraw and
+// produce the garbled output users see when CI detail strings push a
+// line past the terminal width.
+func DisableLineWrap(w *os.File) {
+	_, _ = fmt.Fprint(w, "\033[?7l")
+}
+
+// EnableLineWrap restores the terminal's auto-wrap mode. Always pair it
+// with DisableLineWrap (typically via defer) so an early return does
+// not leave the user's terminal in a clipped state.
+func EnableLineWrap(w *os.File) {
+	_, _ = fmt.Fprint(w, "\033[?7h")
+}
+
 func ColorizeStatus(state StatusState, detail string) string {
 	label := state.String()
 	if detail != "" {

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -123,6 +123,9 @@ func ColorizeStatus(state StatusState, detail string) string {
 	switch state {
 	case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
 		return fmt.Sprintf("\033[32m%s\033[0m", label) // green
+	case StatusFailedSecurity:
+		// Bold + red + reversed background to make security failures stand out.
+		return fmt.Sprintf("\033[1;91m%s\033[0m", label)
 	case StatusFailed, StatusConflict, StatusUntrustedAuthor:
 		return fmt.Sprintf("\033[31m%s\033[0m", label) // red
 	case StatusSkipped:
@@ -136,8 +139,19 @@ func ColorizeStatus(state StatusState, detail string) string {
 
 func PrintPlainResults(w *os.File, status *PRStatus) {
 	merged := status.MergedEntries()
-	failed := status.ActionRequired()
+	actionRequired := status.ActionRequired()
 	skipped := status.SkippedEntries()
+
+	// Split action-required entries into security failures and other failures
+	// so security issues are visually grouped and easy to spot.
+	var securityFailed, otherFailed []StatusEntry
+	for _, e := range actionRequired {
+		if e.State == StatusFailedSecurity {
+			securityFailed = append(securityFailed, e)
+		} else {
+			otherFailed = append(otherFailed, e)
+		}
+	}
 
 	if len(merged) > 0 {
 		_, _ = fmt.Fprintf(w, "Merged (%d):\n", len(merged))
@@ -147,9 +161,18 @@ func PrintPlainResults(w *os.File, status *PRStatus) {
 		_, _ = fmt.Fprintln(w)
 	}
 
-	if len(failed) > 0 {
-		_, _ = fmt.Fprintf(w, "Failed (%d):\n", len(failed))
-		for _, e := range failed {
+	if len(securityFailed) > 0 {
+		_, _ = fmt.Fprintf(w, "Security failures (%d):\n", len(securityFailed))
+		for _, e := range securityFailed {
+			printPlainEntry(w, e)
+			_, _ = fmt.Fprintf(w, "         %s\n", e.PR.URL)
+		}
+		_, _ = fmt.Fprintln(w)
+	}
+
+	if len(otherFailed) > 0 {
+		_, _ = fmt.Fprintf(w, "Failed (%d):\n", len(otherFailed))
+		for _, e := range otherFailed {
 			printPlainEntry(w, e)
 			_, _ = fmt.Fprintf(w, "         %s\n", e.PR.URL)
 		}

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -124,7 +124,8 @@ func ColorizeStatus(state StatusState, detail string) string {
 	case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
 		return fmt.Sprintf("\033[32m%s\033[0m", label) // green
 	case StatusFailedSecurity:
-		// Bold + red + reversed background to make security failures stand out.
+		// Bold + bright red so security failures pop out compared to the
+		// regular red used for ordinary failures.
 		return fmt.Sprintf("\033[1;91m%s\033[0m", label)
 	case StatusFailed, StatusConflict, StatusUntrustedAuthor:
 		return fmt.Sprintf("\033[31m%s\033[0m", label) // red
@@ -139,19 +140,8 @@ func ColorizeStatus(state StatusState, detail string) string {
 
 func PrintPlainResults(w *os.File, status *PRStatus) {
 	merged := status.MergedEntries()
-	actionRequired := status.ActionRequired()
+	securityFailed, otherFailed := SplitActionRequired(status.ActionRequired())
 	skipped := status.SkippedEntries()
-
-	// Split action-required entries into security failures and other failures
-	// so security issues are visually grouped and easy to spot.
-	var securityFailed, otherFailed []StatusEntry
-	for _, e := range actionRequired {
-		if e.State == StatusFailedSecurity {
-			securityFailed = append(securityFailed, e)
-		} else {
-			otherFailed = append(otherFailed, e)
-		}
-	}
 
 	if len(merged) > 0 {
 		_, _ = fmt.Fprintf(w, "Merged (%d):\n", len(merged))
@@ -161,23 +151,8 @@ func PrintPlainResults(w *os.File, status *PRStatus) {
 		_, _ = fmt.Fprintln(w)
 	}
 
-	if len(securityFailed) > 0 {
-		_, _ = fmt.Fprintf(w, "Security failures (%d):\n", len(securityFailed))
-		for _, e := range securityFailed {
-			printPlainEntry(w, e)
-			_, _ = fmt.Fprintf(w, "         %s\n", e.PR.URL)
-		}
-		_, _ = fmt.Fprintln(w)
-	}
-
-	if len(otherFailed) > 0 {
-		_, _ = fmt.Fprintf(w, "Failed (%d):\n", len(otherFailed))
-		for _, e := range otherFailed {
-			printPlainEntry(w, e)
-			_, _ = fmt.Fprintf(w, "         %s\n", e.PR.URL)
-		}
-		_, _ = fmt.Fprintln(w)
-	}
+	printFailureGroup(w, "Security failures", securityFailed)
+	printFailureGroup(w, "Failed", otherFailed)
 
 	if len(skipped) > 0 {
 		_, _ = fmt.Fprintf(w, "Skipped (%d):\n", len(skipped))
@@ -186,6 +161,20 @@ func PrintPlainResults(w *os.File, status *PRStatus) {
 		}
 		_, _ = fmt.Fprintln(w)
 	}
+}
+
+// printFailureGroup writes a header and one entry per failure including its
+// PR URL on a continuation line. It is a no-op when entries is empty.
+func printFailureGroup(w *os.File, header string, entries []StatusEntry) {
+	if len(entries) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s (%d):\n", header, len(entries))
+	for _, e := range entries {
+		printPlainEntry(w, e)
+		_, _ = fmt.Fprintf(w, "         %s\n", e.PR.URL)
+	}
+	_, _ = fmt.Fprintln(w)
 }
 
 func printPlainEntry(w *os.File, e StatusEntry) {

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -33,8 +33,8 @@ type Processor struct {
 
 	// SecurityCheckPatterns is the list of case-insensitive substrings used
 	// to flag failing CI checks as security-related (e.g. govulncheck, Trivy,
-	// CodeQL). Nil uses DefaultSecurityCheckPatterns. Set to a non-nil empty
-	// slice to disable security classification.
+	// CodeQL). A nil slice falls back to DefaultSecurityCheckPatterns; a
+	// non-nil empty slice disables security classification entirely.
 	SecurityCheckPatterns []string
 
 	// MergeMaxRetries is the maximum number of merge attempts when the base
@@ -187,8 +187,8 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	for _, s := range combined.Statuses {
 		state := s.GetState()
 		if state == "failure" || state == "error" {
-			if ctx := s.GetContext(); ctx != "" {
-				failedChecks = append(failedChecks, ctx)
+			if name := s.GetContext(); name != "" {
+				failedChecks = append(failedChecks, name)
 			}
 		}
 	}
@@ -209,11 +209,14 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	return "success", nil, nil
 }
 
+// securityPatterns returns the normalized security-check pattern list to
+// use for classification: nil SecurityCheckPatterns falls back to the
+// built-in defaults; a non-nil empty slice disables classification.
 func (p *Processor) securityPatterns() []string {
 	if p.SecurityCheckPatterns == nil {
-		return DefaultSecurityCheckPatterns
+		return normalizePatterns(defaultSecurityCheckPatterns)
 	}
-	return p.SecurityCheckPatterns
+	return normalizePatterns(p.SecurityCheckPatterns)
 }
 
 // failureDetail builds a human-readable detail string for a non-security

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -31,6 +31,12 @@ type Processor struct {
 	Login          string
 	TrustedAuthors map[string]bool
 
+	// SecurityCheckPatterns is the list of case-insensitive substrings used
+	// to flag failing CI checks as security-related (e.g. govulncheck, Trivy,
+	// CodeQL). Nil uses DefaultSecurityCheckPatterns. Set to a non-nil empty
+	// slice to disable security classification.
+	SecurityCheckPatterns []string
+
 	// MergeMaxRetries is the maximum number of merge attempts when the base
 	// branch is modified between fetch and merge. Zero uses the default (3).
 	MergeMaxRetries int
@@ -110,7 +116,7 @@ func (p *Processor) ProcessPR(ctx context.Context, info pr.PRInfo, status *pr.PR
 func (p *Processor) waitForChecks(ctx context.Context, info pr.PRInfo, status *pr.PRStatus, idx int) error {
 	deadline := time.After(checkPollTimeout)
 	for {
-		state, err := p.getCombinedCheckState(ctx, info)
+		state, failedChecks, err := p.getCombinedCheckState(ctx, info)
 		if err != nil {
 			status.Update(idx, pr.StatusFailed, ghErrorDetail("check error", err))
 			return err
@@ -120,7 +126,11 @@ func (p *Processor) waitForChecks(ctx context.Context, info pr.PRInfo, status *p
 		case "success":
 			return nil
 		case "failure", "error":
-			status.Update(idx, pr.StatusFailed, "checks failed")
+			if name := classifySecurityFailure(failedChecks, p.securityPatterns()); name != "" {
+				status.Update(idx, pr.StatusFailedSecurity, fmt.Sprintf("security check failed: %s", name))
+			} else {
+				status.Update(idx, pr.StatusFailed, failureDetail(failedChecks))
+			}
 			return fmt.Errorf("checks failed")
 		}
 
@@ -138,10 +148,10 @@ func (p *Processor) waitForChecks(ctx context.Context, info pr.PRInfo, status *p
 	}
 }
 
-func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (string, error) {
+func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (string, []string, error) {
 	combined, _, err := p.Client.Repositories.GetCombinedStatus(ctx, info.Owner, info.Repo, fmt.Sprintf("refs/pull/%d/head", info.Number), nil)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	combinedState := combined.GetState()
@@ -149,14 +159,15 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	// Also check check-runs (GitHub Actions use check runs, not commit statuses)
 	checkRuns, _, err := p.Client.Checks.ListCheckRunsForRef(ctx, info.Owner, info.Repo, fmt.Sprintf("refs/pull/%d/head", info.Number), nil)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	if checkRuns.GetTotal() == 0 && len(combined.Statuses) == 0 {
 		// No checks configured -- treat as success
-		return "success", nil
+		return "success", nil, nil
 	}
 
+	var failedChecks []string
 	allComplete := true
 	hasFailure := false
 	for _, cr := range checkRuns.CheckRuns {
@@ -167,23 +178,55 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 		conclusion := cr.GetConclusion()
 		if conclusion == "failure" || conclusion == "timed_out" || conclusion == "cancelled" {
 			hasFailure = true
+			if name := cr.GetName(); name != "" {
+				failedChecks = append(failedChecks, name)
+			}
+		}
+	}
+
+	for _, s := range combined.Statuses {
+		state := s.GetState()
+		if state == "failure" || state == "error" {
+			if ctx := s.GetContext(); ctx != "" {
+				failedChecks = append(failedChecks, ctx)
+			}
 		}
 	}
 
 	if hasFailure {
-		return "failure", nil
+		return "failure", failedChecks, nil
 	}
 	if !allComplete {
-		return "pending", nil
+		return "pending", nil, nil
 	}
 	if combinedState == "failure" || combinedState == "error" {
-		return combinedState, nil
+		return combinedState, failedChecks, nil
 	}
 	if combinedState == "pending" && len(combined.Statuses) > 0 {
-		return "pending", nil
+		return "pending", nil, nil
 	}
 
-	return "success", nil
+	return "success", nil, nil
+}
+
+func (p *Processor) securityPatterns() []string {
+	if p.SecurityCheckPatterns == nil {
+		return DefaultSecurityCheckPatterns
+	}
+	return p.SecurityCheckPatterns
+}
+
+// failureDetail builds a human-readable detail string for a non-security
+// check failure, naming the failing checks when available.
+func failureDetail(failedChecks []string) string {
+	if len(failedChecks) == 0 {
+		return "checks failed"
+	}
+	const maxShow = 3
+	if len(failedChecks) <= maxShow {
+		return fmt.Sprintf("checks failed: %s", strings.Join(failedChecks, ", "))
+	}
+	return fmt.Sprintf("checks failed: %s (+%d more)", strings.Join(failedChecks[:maxShow], ", "), len(failedChecks)-maxShow)
 }
 
 func (p *Processor) approve(ctx context.Context, info pr.PRInfo, status *pr.PRStatus, idx int) error {

--- a/internal/process/security.go
+++ b/internal/process/security.go
@@ -2,7 +2,7 @@ package process
 
 import "strings"
 
-// DefaultSecurityCheckPatterns is the default list of case-insensitive
+// defaultSecurityCheckPatterns is the built-in list of case-insensitive
 // substrings that mark a CI check as security-relevant. When a check whose
 // name matches one of these patterns fails, the PR is reported with a
 // distinct status so downstream tooling (and humans) do not treat it as
@@ -14,8 +14,7 @@ import "strings"
 // the official github/codeql-action template's "Analyze (go)" -- the
 // "codeql" substring will not catch that, so CodeQL users who rely on the
 // default job name should extend this list via --security-patterns.
-var DefaultSecurityCheckPatterns = []string{
-	"security scan",
+var defaultSecurityCheckPatterns = []string{
 	"security",
 	"govulncheck",
 	"trivy",
@@ -34,9 +33,33 @@ var DefaultSecurityCheckPatterns = []string{
 	"dependency review",
 }
 
+// DefaultSecurityCheckPatterns returns a fresh copy of the built-in
+// security-check pattern list. Returning a copy guarantees that callers
+// cannot accidentally mutate the package-level default.
+func DefaultSecurityCheckPatterns() []string {
+	out := make([]string, len(defaultSecurityCheckPatterns))
+	copy(out, defaultSecurityCheckPatterns)
+	return out
+}
+
+// normalizePatterns lower-cases and trims each entry, dropping empties.
+// Returning a normalized slice once lets the hot loop in
+// classifySecurityFailure use a plain strings.Contains.
+func normalizePatterns(patterns []string) []string {
+	out := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
 // classifySecurityFailure returns the name of the first failing check that
 // matches any of the configured security patterns, or "" if none match.
-// Matching is case-insensitive substring match against the check name.
+// Patterns must already be normalized (see normalizePatterns); matching is
+// a case-insensitive substring match against the check name.
 func classifySecurityFailure(failedChecks []string, patterns []string) string {
 	if len(failedChecks) == 0 || len(patterns) == 0 {
 		return ""
@@ -44,10 +67,6 @@ func classifySecurityFailure(failedChecks []string, patterns []string) string {
 	for _, name := range failedChecks {
 		lower := strings.ToLower(name)
 		for _, p := range patterns {
-			p = strings.TrimSpace(strings.ToLower(p))
-			if p == "" {
-				continue
-			}
 			if strings.Contains(lower, p) {
 				return name
 			}

--- a/internal/process/security.go
+++ b/internal/process/security.go
@@ -7,6 +7,13 @@ import "strings"
 // name matches one of these patterns fails, the PR is reported with a
 // distinct status so downstream tooling (and humans) do not treat it as
 // ordinary build/test flakiness.
+//
+// Patterns are validated against real-world check-run names observed in
+// production workflows (e.g. aquasecurity/trivy's "Scan Go vulnerabilities"
+// matches via "vulnerabilities"). Some scanners use generic job names like
+// the official github/codeql-action template's "Analyze (go)" -- the
+// "codeql" substring will not catch that, so CodeQL users who rely on the
+// default job name should extend this list via --security-patterns.
 var DefaultSecurityCheckPatterns = []string{
 	"security scan",
 	"security",
@@ -15,6 +22,10 @@ var DefaultSecurityCheckPatterns = []string{
 	"codeql",
 	"snyk",
 	"gosec",
+	"gitleaks",
+	"semgrep",
+	"checkov",
+	"kics",
 	"vulnerability",
 	"vulnerabilities",
 	"sast",

--- a/internal/process/security.go
+++ b/internal/process/security.go
@@ -1,0 +1,46 @@
+package process
+
+import "strings"
+
+// DefaultSecurityCheckPatterns is the default list of case-insensitive
+// substrings that mark a CI check as security-relevant. When a check whose
+// name matches one of these patterns fails, the PR is reported with a
+// distinct status so downstream tooling (and humans) do not treat it as
+// ordinary build/test flakiness.
+var DefaultSecurityCheckPatterns = []string{
+	"security scan",
+	"security",
+	"govulncheck",
+	"trivy",
+	"codeql",
+	"snyk",
+	"gosec",
+	"vulnerability",
+	"vulnerabilities",
+	"sast",
+	"dast",
+	"dependency-review",
+	"dependency review",
+}
+
+// classifySecurityFailure returns the name of the first failing check that
+// matches any of the configured security patterns, or "" if none match.
+// Matching is case-insensitive substring match against the check name.
+func classifySecurityFailure(failedChecks []string, patterns []string) string {
+	if len(failedChecks) == 0 || len(patterns) == 0 {
+		return ""
+	}
+	for _, name := range failedChecks {
+		lower := strings.ToLower(name)
+		for _, p := range patterns {
+			p = strings.TrimSpace(strings.ToLower(p))
+			if p == "" {
+				continue
+			}
+			if strings.Contains(lower, p) {
+				return name
+			}
+		}
+	}
+	return ""
+}

--- a/internal/process/security_test.go
+++ b/internal/process/security_test.go
@@ -3,6 +3,8 @@ package process
 import "testing"
 
 func TestClassifySecurityFailure_defaults(t *testing.T) {
+	defaults := normalizePatterns(DefaultSecurityCheckPatterns())
+
 	tests := []struct {
 		name          string
 		failedChecks  []string
@@ -47,7 +49,7 @@ func TestClassifySecurityFailure_defaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifySecurityFailure(tt.failedChecks, DefaultSecurityCheckPatterns)
+			got := classifySecurityFailure(tt.failedChecks, defaults)
 			if tt.wantNonEmpty && got == "" {
 				t.Errorf("classifySecurityFailure(%v) returned empty, want non-empty", tt.failedChecks)
 			}
@@ -62,7 +64,7 @@ func TestClassifySecurityFailure_defaults(t *testing.T) {
 }
 
 func TestClassifySecurityFailure_customPatterns(t *testing.T) {
-	patterns := []string{"my-custom-scan"}
+	patterns := normalizePatterns([]string{"my-custom-scan"})
 
 	if got := classifySecurityFailure([]string{"govulncheck"}, patterns); got != "" {
 		t.Errorf("govulncheck should not match custom patterns; got %q", got)
@@ -79,13 +81,29 @@ func TestClassifySecurityFailure_emptyPatternsDisableClassification(t *testing.T
 	}
 }
 
-func TestClassifySecurityFailure_ignoresBlankPatternEntries(t *testing.T) {
-	patterns := []string{"", "   ", "trivy"}
-	if got := classifySecurityFailure([]string{"build"}, patterns); got != "" {
-		t.Errorf("blank pattern entries must not match arbitrary check names; got %q", got)
+func TestNormalizePatterns_dropsBlankAndNormalizesCase(t *testing.T) {
+	got := normalizePatterns([]string{"", "  ", "Trivy", " GoVulnCheck "})
+	want := []string{"trivy", "govulncheck"}
+	if len(got) != len(want) {
+		t.Fatalf("normalizePatterns len = %d, want %d (got %v)", len(got), len(want), got)
 	}
-	if got := classifySecurityFailure([]string{"Trivy"}, patterns); got == "" {
-		t.Errorf("expected non-blank pattern to still match")
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("normalizePatterns[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDefaultSecurityCheckPatterns_returnsCopy(t *testing.T) {
+	a := DefaultSecurityCheckPatterns()
+	if len(a) == 0 {
+		t.Fatal("expected non-empty default patterns")
+	}
+	a[0] = "MUTATED"
+
+	b := DefaultSecurityCheckPatterns()
+	if b[0] == "MUTATED" {
+		t.Fatal("DefaultSecurityCheckPatterns must return an independent copy")
 	}
 }
 
@@ -112,6 +130,8 @@ func TestProcessorSecurityPatterns_emptyDisablesClassification(t *testing.T) {
 //   - teemow/inboxfewer:     "gitleaks", "Lint and Test", "build-and-push"
 //   - teemow/stammbaum:      "backend"
 func TestClassifySecurityFailure_realWorldNames(t *testing.T) {
+	defaults := normalizePatterns(DefaultSecurityCheckPatterns())
+
 	tests := []struct {
 		name         string
 		checkName    string
@@ -127,7 +147,7 @@ func TestClassifySecurityFailure_realWorldNames(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifySecurityFailure([]string{tt.checkName}, DefaultSecurityCheckPatterns)
+			got := classifySecurityFailure([]string{tt.checkName}, defaults)
 			if tt.wantSecurity && got == "" {
 				t.Errorf("expected %q to be classified as security, but it was not", tt.checkName)
 			}

--- a/internal/process/security_test.go
+++ b/internal/process/security_test.go
@@ -1,0 +1,125 @@
+package process
+
+import "testing"
+
+func TestClassifySecurityFailure_defaults(t *testing.T) {
+	tests := []struct {
+		name          string
+		failedChecks  []string
+		wantNonEmpty  bool
+		wantMatchedIs string
+	}{
+		{
+			name:          "govulncheck check matches",
+			failedChecks:  []string{"build", "govulncheck"},
+			wantNonEmpty:  true,
+			wantMatchedIs: "govulncheck",
+		},
+		{
+			name:          "Trivy check matches case-insensitively",
+			failedChecks:  []string{"TRIVY: container scan"},
+			wantNonEmpty:  true,
+			wantMatchedIs: "TRIVY: container scan",
+		},
+		{
+			name:          "CodeQL Analysis matches",
+			failedChecks:  []string{"CodeQL Analysis (go)"},
+			wantNonEmpty:  true,
+			wantMatchedIs: "CodeQL Analysis (go)",
+		},
+		{
+			name:          "Security Scan matches",
+			failedChecks:  []string{"Security Scan"},
+			wantNonEmpty:  true,
+			wantMatchedIs: "Security Scan",
+		},
+		{
+			name:         "build/test failure does not match",
+			failedChecks: []string{"build", "unit-tests", "lint"},
+			wantNonEmpty: false,
+		},
+		{
+			name:         "no failed checks returns empty",
+			failedChecks: nil,
+			wantNonEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySecurityFailure(tt.failedChecks, DefaultSecurityCheckPatterns)
+			if tt.wantNonEmpty && got == "" {
+				t.Errorf("classifySecurityFailure(%v) returned empty, want non-empty", tt.failedChecks)
+			}
+			if !tt.wantNonEmpty && got != "" {
+				t.Errorf("classifySecurityFailure(%v) = %q, want empty", tt.failedChecks, got)
+			}
+			if tt.wantNonEmpty && tt.wantMatchedIs != "" && got != tt.wantMatchedIs {
+				t.Errorf("classifySecurityFailure(%v) = %q, want %q", tt.failedChecks, got, tt.wantMatchedIs)
+			}
+		})
+	}
+}
+
+func TestClassifySecurityFailure_customPatterns(t *testing.T) {
+	patterns := []string{"my-custom-scan"}
+
+	if got := classifySecurityFailure([]string{"govulncheck"}, patterns); got != "" {
+		t.Errorf("govulncheck should not match custom patterns; got %q", got)
+	}
+
+	if got := classifySecurityFailure([]string{"My-Custom-Scan failed"}, patterns); got == "" {
+		t.Errorf("expected custom pattern to match case-insensitively")
+	}
+}
+
+func TestClassifySecurityFailure_emptyPatternsDisableClassification(t *testing.T) {
+	if got := classifySecurityFailure([]string{"govulncheck"}, []string{}); got != "" {
+		t.Errorf("empty patterns should disable classification; got %q", got)
+	}
+}
+
+func TestClassifySecurityFailure_ignoresBlankPatternEntries(t *testing.T) {
+	patterns := []string{"", "   ", "trivy"}
+	if got := classifySecurityFailure([]string{"build"}, patterns); got != "" {
+		t.Errorf("blank pattern entries must not match arbitrary check names; got %q", got)
+	}
+	if got := classifySecurityFailure([]string{"Trivy"}, patterns); got == "" {
+		t.Errorf("expected non-blank pattern to still match")
+	}
+}
+
+func TestProcessorSecurityPatterns_defaultWhenNil(t *testing.T) {
+	p := &Processor{}
+	if got := p.securityPatterns(); len(got) == 0 {
+		t.Fatal("expected default security patterns when SecurityCheckPatterns is nil")
+	}
+}
+
+func TestProcessorSecurityPatterns_emptyDisablesClassification(t *testing.T) {
+	p := &Processor{SecurityCheckPatterns: []string{}}
+	got := p.securityPatterns()
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice to be preserved (classification disabled); got %v", got)
+	}
+}
+
+func TestFailureDetail(t *testing.T) {
+	tests := []struct {
+		name         string
+		failedChecks []string
+		want         string
+	}{
+		{"no checks", nil, "checks failed"},
+		{"one check", []string{"build"}, "checks failed: build"},
+		{"three checks", []string{"a", "b", "c"}, "checks failed: a, b, c"},
+		{"more than three", []string{"a", "b", "c", "d", "e"}, "checks failed: a, b, c (+2 more)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := failureDetail(tt.failedChecks); got != tt.want {
+				t.Errorf("failureDetail(%v) = %q, want %q", tt.failedChecks, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/process/security_test.go
+++ b/internal/process/security_test.go
@@ -104,6 +104,40 @@ func TestProcessorSecurityPatterns_emptyDisablesClassification(t *testing.T) {
 	}
 }
 
+// TestClassifySecurityFailure_realWorldNames feeds actual check-run names
+// observed in production GitHub Actions workflows through the classifier.
+// Names captured from live API responses on 2026-05-18:
+//   - aquasecurity/trivy:    "Scan Go vulnerabilities"
+//   - golang/vuln (CodeQL):  "Analyze (go)"
+//   - teemow/inboxfewer:     "gitleaks", "Lint and Test", "build-and-push"
+//   - teemow/stammbaum:      "backend"
+func TestClassifySecurityFailure_realWorldNames(t *testing.T) {
+	tests := []struct {
+		name         string
+		checkName    string
+		wantSecurity bool
+	}{
+		{"aquasecurity trivy scan", "Scan Go vulnerabilities", true},
+		{"gitleaks default", "gitleaks", true},
+		{"CodeQL default job name", "Analyze (go)", false}, // documents the known gap
+		{"build failure", "Lint and Test", false},
+		{"docker build", "build-and-push", false},
+		{"generic backend job", "backend", false},
+		{"go test job", "Test (macos-latest)", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySecurityFailure([]string{tt.checkName}, DefaultSecurityCheckPatterns)
+			if tt.wantSecurity && got == "" {
+				t.Errorf("expected %q to be classified as security, but it was not", tt.checkName)
+			}
+			if !tt.wantSecurity && got != "" {
+				t.Errorf("expected %q NOT to be classified as security, but it was (matched as %q)", tt.checkName, got)
+			}
+		})
+	}
+}
+
 func TestFailureDetail(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

Adds a sub-classification for failing CI checks so security scan failures (govulncheck, Trivy, CodeQL, Snyk, gosec, ...) are no longer lumped together with build/test flakes in `marge sweep` output. Closes #24.

- New `pr.StatusFailedSecurity` state, rendered as `Failed (security)` with a bold + bright-red label in the TUI.
- Sweep output (TUI and `--no-tui`) groups security failures into a dedicated section, separate from the existing "Action required" / "Failed" section.
- The MCP `sweep` tool now returns a separate `security_failures` array and `summary.security_failures` count alongside the existing fields, so downstream agents can branch on it explicitly. `summary.failed` and `summary.security_failures` are **disjoint** (security entries are not counted in `failed`), so consumers can sum them without double-counting.
- New `--security-patterns` flag on `marge run` and `marge sweep` (and `security_patterns` argument on the MCP tool) accepts a comma-separated case-insensitive substring list that overrides the built-in defaults. The default list lives in `internal/process/security.go` and is exposed via `DefaultSecurityCheckPatterns()` (which returns a copy).
- Processor now tracks the names of failing checks and uses them both for security classification and for a richer "checks failed: <names>" detail string on non-security failures.

## Internal cleanup

Code-review polish landed in the same branch:

- `getCombinedCheckState`: renamed shadowed `ctx` local to avoid colliding with the `context.Context` parameter.
- `internal/process/security.go`: dropped the redundant `"security scan"` pattern (subsumed by `"security"`); patterns are normalized once and the hot path uses plain `strings.Contains`; `DefaultSecurityCheckPatterns()` returns a fresh copy each call.
- `cmd/common.go`: collapsed `parseSecurityPatterns` and `parseTrustedAuthors` onto a single `parseCSVList` helper; removed the `processOnce` one-line wrapper now that all callers want the status back.
- `internal/pr` + `cmd/sweep.go`: extracted `pr.SplitActionRequired` and shared print helpers so the "security vs other failure" split lives in exactly one place.
- README: shortened the long flag-table row; the full default pattern list and the CodeQL `Analyze (<lang>)` caveat now live in a dedicated subsection below the table.

## Behavior change

- Sweep / run still exit on the same conditions; security failures still count as failures in the CLI summary line. The difference is purely how they are surfaced. The MCP `summary.failed` count changes shape: it no longer includes security failures (now reported in `summary.security_failures`).

## Test plan

- [x] `make test` (unit tests cover the classification helper and its real-world fixtures, processor defaults, status counting, plain-output grouping, CLI flag parsing, colorization distinctness, the disjoint-summary contract for `buildSweepResult`, and that `DefaultSecurityCheckPatterns()` returns an independent copy)
- [x] `go vet ./...`, `staticcheck ./...`, `golangci-lint run ./...` all clean
- [x] `marge sweep --help` shows the new flag