### PR TITLE
Distinguish CI-unavailable (Actions budget) from real failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ The built-in list contains: `security`, `govulncheck`, `trivy`, `codeql`, `snyk`
 
 Pass `--security-patterns "Trivy,Govulncheck,CodeQL,Analyze"` to replace the list. The github/codeql-action template uses a job name like `Analyze (<lang>)` that the `codeql` substring will not match, so add `Analyze` if you rely on that template.
 
+#### CI unavailable (Actions budget)
+
+Sometimes a check reports `failure` not because the code is broken but because GitHub never started the job -- e.g. a personal account or organization has exhausted its Actions spending limit. The check annotation then reads `The job was not started because an Actions budget is preventing further use.`
+
+When **every** failing check on a PR carries such a budget/spending-limit annotation, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
+
 ### `marge sweep [flags]`
 
-Processes all matching PRs without interactive grouping. After processing, prints a **Security failures** section followed by an **Action required** section listing any PRs that failed, have conflicts, or came from untrusted authors. Security failures (e.g. govulncheck, Trivy, CodeQL) are separated so they are not mistaken for ordinary CI flakiness.
+Processes all matching PRs without interactive grouping. After processing, prints a **Security failures** section, an **Action required** section listing any PRs that failed, have conflicts, or came from untrusted authors, and a **CI unavailable (Actions budget)** section for PRs whose checks never ran because an Actions spending limit was exhausted. Security failures (e.g. govulncheck, Trivy, CodeQL) are separated so they are not mistaken for ordinary CI flakiness, and budget-blocked PRs are separated so they are not mistaken for genuine failures (see [CI unavailable (Actions budget)](#ci-unavailable-actions-budget)).
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|

--- a/README.md
+++ b/README.md
@@ -86,17 +86,15 @@ Pass `--security-patterns "Trivy,Govulncheck,CodeQL,Analyze"` to replace the lis
 
 #### CI unavailable (Actions budget)
 
-Sometimes a check reports `failure` not because the code is broken but because GitHub never started the job -- e.g. a personal account or organization has exhausted its Actions budget, hit its spending limit, or has a failed payment. GitHub surfaces this as a job that never reached the runner, with messages such as:
+Sometimes a check reports `failure` not because the code is broken but because GitHub never started the job -- a personal account or organization has exhausted its Actions budget. GitHub surfaces this as a job that never reached the runner:
 
 - `The job was not started because an Actions budget is preventing further use.`
-- `The job was not started because recent account payments have failed or your spending limit needs to be increased. ...`
-- `The job was not started because your account is locked due to a billing issue.`
 
-Verified against the live GitHub API, such a block shows up as a check run with conclusion `failure`, empty `output`, and a single failure-level **annotation** whose `message` carries the text above (the message is in the annotation, not the output fields). marge therefore inspects each failed check run's annotations and detects the block by the platform prefix `the job was not started because` paired with a billing/budget marker -- a prefix that never appears for a genuine test, build, or lint failure.
+Verified against the live GitHub API, such a block shows up as a check run with conclusion `failure`, empty `output`, and a single failure-level **annotation** whose `message` carries the text above (the message is in the annotation, not the output fields). marge therefore inspects each failed check run's annotations and matches that message -- which never appears for a genuine test, build, or lint failure.
 
 When **every** failing check on a PR is such a block, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
 
-> Detection is deliberately conservative: an unrecognized variant degrades to the normal `Failed` path rather than risking a real failure being hidden.
+> Only this API-verified message is matched; any unrecognized block degrades to the normal `Failed` path rather than risking a real failure being hidden.
 
 ### `marge sweep [flags]`
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,15 @@ Pass `--security-patterns "Trivy,Govulncheck,CodeQL,Analyze"` to replace the lis
 
 #### CI unavailable (Actions budget)
 
-Sometimes a check reports `failure` not because the code is broken but because GitHub never started the job -- e.g. a personal account or organization has exhausted its Actions spending limit. The check annotation then reads `The job was not started because an Actions budget is preventing further use.`
+Sometimes a check reports `failure` not because the code is broken but because GitHub never started the job -- e.g. a personal account or organization has exhausted its Actions budget, hit its spending limit, or has a failed payment. GitHub surfaces this as a job that never reached the runner, with messages such as:
 
-When **every** failing check on a PR carries such a budget/spending-limit annotation, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
+- `The job was not started because an Actions budget is preventing further use.`
+- `The job was not started because recent account payments have failed or your spending limit needs to be increased. ...`
+- `The job was not started because your account is locked due to a billing issue.`
+
+marge detects these by the platform prefix `the job was not started because` paired with a billing/budget marker (the prefix never appears for a genuine test, build, or lint failure). When **every** failing check on a PR is such a block, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
+
+> Detection is best-effort string matching against the messages GitHub is known to emit; it is deliberately conservative, so an unrecognized variant degrades to the normal `Failed` path rather than risking a real failure being hidden.
 
 ### `marge sweep [flags]`
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Sometimes a check reports `failure` not because the code is broken but because G
 - `The job was not started because recent account payments have failed or your spending limit needs to be increased. ...`
 - `The job was not started because your account is locked due to a billing issue.`
 
-marge detects these by the platform prefix `the job was not started because` paired with a billing/budget marker (the prefix never appears for a genuine test, build, or lint failure). When **every** failing check on a PR is such a block, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
+Verified against the live GitHub API, such a block shows up as a check run with conclusion `failure`, empty `output`, and a single failure-level **annotation** whose `message` carries the text above (the message is in the annotation, not the output fields). marge therefore inspects each failed check run's annotations and detects the block by the platform prefix `the job was not started because` paired with a billing/budget marker -- a prefix that never appears for a genuine test, build, or lint failure.
 
-> Detection is best-effort string matching against the messages GitHub is known to emit; it is deliberately conservative, so an unrecognized variant degrades to the normal `Failed` path rather than risking a real failure being hidden.
+When **every** failing check on a PR is such a block, marge classifies the PR as `CI unavailable (budget)` rather than `Failed`. It is counted separately, surfaced under its own section, and kept out of any rescue path -- the fix is to raise or await the Actions budget, not to touch the code. If a PR has a mix of a genuine failure and a budget block, it is still reported as `Failed`.
+
+> Detection is deliberately conservative: an unrecognized variant degrades to the normal `Failed` path rather than risking a real failure being hidden.
 
 ### `marge sweep [flags]`
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -75,7 +75,12 @@ type SweepResult struct {
 	Merged           []SweepPREntry `json:"merged,omitempty"`
 	SecurityFailures []SweepPREntry `json:"security_failures,omitempty"`
 	ActionRequired   []SweepPREntry `json:"action_required,omitempty"`
-	Skipped          []SweepPREntry `json:"skipped,omitempty"`
+	// CIUnavailable lists PRs whose CI could not run because a GitHub Actions
+	// budget / spending-limit block prevented every job from starting. These
+	// are NOT failures: the remedy is to raise or await the Actions budget,
+	// so they are reported separately and excluded from action_required.
+	CIUnavailable []SweepPREntry `json:"ci_unavailable,omitempty"`
+	Skipped       []SweepPREntry `json:"skipped,omitempty"`
 }
 
 // SweepSummary contains aggregate counts from the sweep.
@@ -89,7 +94,10 @@ type SweepSummary struct {
 	Merged           int `json:"merged"`
 	Failed           int `json:"failed"`
 	SecurityFailures int `json:"security_failures"`
-	Skipped          int `json:"skipped"`
+	// CIUnavailable counts PRs whose CI could not run because of a GitHub
+	// Actions budget block. It is disjoint from Failed and SecurityFailures.
+	CIUnavailable int `json:"ci_unavailable"`
+	Skipped       int `json:"skipped"`
 }
 
 // SweepPREntry represents a single PR in the sweep results.
@@ -174,9 +182,10 @@ func handleSweep(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToo
 }
 
 func buildSweepResult(status *pr.PRStatus) SweepResult {
-	merged, failed, skipped := status.Summary()
+	merged, failed, blocked, skipped := status.Summary()
 	total := status.Len()
 	securityEntries := status.SecurityFailedEntries()
+	blockedEntries := status.BlockedEntries()
 
 	result := SweepResult{
 		Summary: SweepSummary{
@@ -184,6 +193,7 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 			Merged:           merged,
 			Failed:           failed - len(securityEntries),
 			SecurityFailures: len(securityEntries),
+			CIUnavailable:    blocked,
 			Skipped:          skipped,
 		},
 	}
@@ -206,6 +216,10 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 
 	for _, e := range securityEntries {
 		result.SecurityFailures = append(result.SecurityFailures, toEntry(e))
+	}
+
+	for _, e := range blockedEntries {
+		result.CIUnavailable = append(result.CIUnavailable, toEntry(e))
 	}
 
 	for _, e := range status.ActionRequired() {

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -53,3 +53,35 @@ func TestBuildSweepResult_failedAndSecurityAreDisjoint(t *testing.T) {
 		t.Errorf("ActionRequired[0].Number = %d, want 1", got.ActionRequired[0].Number)
 	}
 }
+
+// TestBuildSweepResult_ciUnavailableIsSeparate guards that a PR blocked by a
+// GitHub Actions budget is reported under ci_unavailable and excluded from
+// both the failed count and action_required, so rescue tooling never picks
+// it up.
+func TestBuildSweepResult_ciUnavailableIsSeparate(t *testing.T) {
+	status := pr.NewPRStatus()
+	idx1 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 1})
+	status.Update(idx1, pr.StatusFailed, "checks failed: build")
+	idx2 := status.Add(pr.PRInfo{Owner: "o", Repo: "r", Number: 2})
+	status.Update(idx2, pr.StatusBlockedCI, "Actions budget exhausted; no jobs ran: Test, Lint")
+
+	got := buildSweepResult(status)
+
+	if got.Summary.Failed != 1 {
+		t.Errorf("Failed = %d, want 1 (budget block must be excluded)", got.Summary.Failed)
+	}
+	if got.Summary.CIUnavailable != 1 {
+		t.Errorf("CIUnavailable = %d, want 1", got.Summary.CIUnavailable)
+	}
+	if len(got.CIUnavailable) != 1 {
+		t.Fatalf("CIUnavailable slice len = %d, want 1", len(got.CIUnavailable))
+	}
+	if got.CIUnavailable[0].Number != 2 {
+		t.Errorf("CIUnavailable[0].Number = %d, want 2", got.CIUnavailable[0].Number)
+	}
+	for _, e := range got.ActionRequired {
+		if e.Number == 2 {
+			t.Error("budget-blocked PR must not appear in action_required")
+		}
+	}
+}

--- a/cmd/sweep.go
+++ b/cmd/sweep.go
@@ -73,6 +73,7 @@ that could not be merged so you can fix them manually.`,
 					security, other := pr.SplitActionRequired(status.ActionRequired())
 					printSweepFailures(os.Stderr, "Security failures", security)
 					printSweepFailures(os.Stderr, "Action required", other)
+					printSweepFailures(os.Stderr, "CI unavailable (Actions budget)", status.BlockedEntries())
 				}
 			}
 

--- a/internal/pr/status.go
+++ b/internal/pr/status.go
@@ -18,6 +18,7 @@ const (
 	StatusAutoMerge
 	StatusFailed
 	StatusFailedSecurity
+	StatusBlockedCI
 	StatusSkipped
 	StatusConflict
 	StatusUntrustedAuthor
@@ -45,6 +46,8 @@ func (s StatusState) String() string {
 		return "Failed"
 	case StatusFailedSecurity:
 		return "Failed (security)"
+	case StatusBlockedCI:
+		return "CI unavailable (budget)"
 	case StatusSkipped:
 		return "Skipped"
 	case StatusConflict:
@@ -99,20 +102,30 @@ func (s *PRStatus) Snapshot() []StatusEntry {
 	return snap
 }
 
-func (s *PRStatus) Summary() (merged, failed, skipped int) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+// countsLocked tallies entries by category. blocked (CI could not run because
+// of an Actions budget block) is counted separately from failed so a billing
+// block is never mistaken for a genuine CI failure. Callers must hold s.mu.
+func (s *PRStatus) countsLocked() (merged, failed, blocked, skipped int) {
 	for _, e := range s.entries {
 		switch e.State {
 		case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
 			merged++
 		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
 			failed++
+		case StatusBlockedCI:
+			blocked++
 		case StatusSkipped:
 			skipped++
 		}
 	}
 	return
+}
+
+// Summary returns aggregate counts across all entries.
+func (s *PRStatus) Summary() (merged, failed, blocked, skipped int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.countsLocked()
 }
 
 func (s *PRStatus) Len() int {
@@ -124,18 +137,12 @@ func (s *PRStatus) Len() int {
 func (s *PRStatus) FormatSummary() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var merged, failed, skipped int
-	for _, e := range s.entries {
-		switch e.State {
-		case StatusMerged, StatusAlreadyMerged, StatusAutoMerge:
-			merged++
-		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
-			failed++
-		case StatusSkipped:
-			skipped++
-		}
-	}
+	merged, failed, blocked, skipped := s.countsLocked()
 	total := len(s.entries)
+	if blocked > 0 {
+		return fmt.Sprintf("%d PRs processed: %d merged, %d failed, %d CI-unavailable, %d skipped",
+			total, merged, failed, blocked, skipped)
+	}
 	return fmt.Sprintf("%d PRs processed: %d merged, %d failed, %d skipped", total, merged, failed, skipped)
 }
 
@@ -146,6 +153,22 @@ func (s *PRStatus) ActionRequired() []StatusEntry {
 	for _, e := range s.entries {
 		switch e.State {
 		case StatusFailed, StatusFailedSecurity, StatusConflict, StatusUntrustedAuthor:
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+// BlockedEntries returns entries whose CI could not run because a GitHub
+// Actions budget / spending-limit block prevented every job from starting.
+// These are deliberately kept out of ActionRequired and the failed counts:
+// the remedy is "raise or await the Actions budget", not "rescue the code".
+func (s *PRStatus) BlockedEntries() []StatusEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []StatusEntry
+	for _, e := range s.entries {
+		if e.State == StatusBlockedCI {
 			result = append(result, e)
 		}
 	}

--- a/internal/pr/status_test.go
+++ b/internal/pr/status_test.go
@@ -16,12 +16,12 @@ func TestStatus_securityFailureCountedAsFailed(t *testing.T) {
 	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 1})
 	s.Update(idx, StatusFailedSecurity, "security check failed: govulncheck")
 
-	merged, failed, skipped := s.Summary()
+	merged, failed, blocked, skipped := s.Summary()
 	if failed != 1 {
 		t.Errorf("Summary failed = %d, want 1", failed)
 	}
-	if merged != 0 || skipped != 0 {
-		t.Errorf("Summary merged=%d skipped=%d, want zero", merged, skipped)
+	if merged != 0 || blocked != 0 || skipped != 0 {
+		t.Errorf("Summary merged=%d blocked=%d skipped=%d, want zero", merged, blocked, skipped)
 	}
 }
 
@@ -41,6 +41,70 @@ func TestStatus_securityFailureInActionRequired(t *testing.T) {
 	sec := s.SecurityFailedEntries()
 	if len(sec) != 1 {
 		t.Fatalf("SecurityFailedEntries len = %d, want 1", len(sec))
+	}
+}
+
+func TestStatusBlockedCI_string(t *testing.T) {
+	if got := StatusBlockedCI.String(); got != "CI unavailable (budget)" {
+		t.Errorf("StatusBlockedCI.String() = %q, want %q", got, "CI unavailable (budget)")
+	}
+}
+
+func TestStatus_blockedNotCountedAsFailed(t *testing.T) {
+	s := NewPRStatus()
+	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 1})
+	s.Update(idx, StatusBlockedCI, "Actions budget exhausted; no jobs ran")
+
+	merged, failed, blocked, skipped := s.Summary()
+	if blocked != 1 {
+		t.Errorf("Summary blocked = %d, want 1", blocked)
+	}
+	if failed != 0 {
+		t.Errorf("Summary failed = %d, want 0 (budget block must not count as failed)", failed)
+	}
+	if merged != 0 || skipped != 0 {
+		t.Errorf("Summary merged=%d skipped=%d, want zero", merged, skipped)
+	}
+}
+
+func TestStatus_blockedNotInActionRequired(t *testing.T) {
+	s := NewPRStatus()
+	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 42})
+	s.Update(idx, StatusBlockedCI, "Actions budget exhausted; no jobs ran: Test, Lint")
+
+	if ar := s.ActionRequired(); len(ar) != 0 {
+		t.Errorf("ActionRequired len = %d, want 0 (budget block must be kept out of the rescue path)", len(ar))
+	}
+
+	blocked := s.BlockedEntries()
+	if len(blocked) != 1 {
+		t.Fatalf("BlockedEntries len = %d, want 1", len(blocked))
+	}
+	if blocked[0].PR.Number != 42 {
+		t.Errorf("BlockedEntries[0].Number = %d, want 42", blocked[0].PR.Number)
+	}
+}
+
+func TestFormatSummary_includesBlockedWhenPresent(t *testing.T) {
+	s := NewPRStatus()
+	idx := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 1})
+	s.Update(idx, StatusBlockedCI, "Actions budget exhausted; no jobs ran")
+
+	if got := s.FormatSummary(); !strings.Contains(got, "CI-unavailable") {
+		t.Errorf("FormatSummary() = %q, want it to mention CI-unavailable", got)
+	}
+}
+
+func TestColorizeStatus_blockedIsDistinct(t *testing.T) {
+	failed := ColorizeStatus(StatusFailed, "checks failed")
+	blocked := ColorizeStatus(StatusBlockedCI, "Actions budget exhausted")
+	skipped := ColorizeStatus(StatusSkipped, "dry-run")
+
+	if blocked == failed {
+		t.Error("ColorizeStatus for StatusBlockedCI and StatusFailed must differ")
+	}
+	if blocked == skipped {
+		t.Error("ColorizeStatus for StatusBlockedCI and StatusSkipped must differ")
 	}
 }
 

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -146,6 +146,10 @@ func ColorizeStatus(state StatusState, detail string) string {
 		return fmt.Sprintf("\033[1;91m%s\033[0m", label)
 	case StatusFailed, StatusConflict, StatusUntrustedAuthor:
 		return fmt.Sprintf("\033[31m%s\033[0m", label) // red
+	case StatusBlockedCI:
+		// Magenta so a billing/budget block reads as "not a code failure",
+		// distinct from the red used for genuine failures.
+		return fmt.Sprintf("\033[35m%s\033[0m", label)
 	case StatusSkipped:
 		return fmt.Sprintf("\033[33m%s\033[0m", label) // yellow
 	case StatusChecking, StatusApproving, StatusMerging:
@@ -158,6 +162,7 @@ func ColorizeStatus(state StatusState, detail string) string {
 func PrintPlainResults(w *os.File, status *PRStatus) {
 	merged := status.MergedEntries()
 	securityFailed, otherFailed := SplitActionRequired(status.ActionRequired())
+	blocked := status.BlockedEntries()
 	skipped := status.SkippedEntries()
 
 	if len(merged) > 0 {
@@ -170,6 +175,7 @@ func PrintPlainResults(w *os.File, status *PRStatus) {
 
 	printFailureGroup(w, "Security failures", securityFailed)
 	printFailureGroup(w, "Failed", otherFailed)
+	printFailureGroup(w, "CI unavailable (Actions budget)", blocked)
 
 	if len(skipped) > 0 {
 		_, _ = fmt.Fprintf(w, "Skipped (%d):\n", len(skipped))

--- a/internal/process/budget.go
+++ b/internal/process/budget.go
@@ -1,0 +1,87 @@
+package process
+
+import (
+	"fmt"
+	"strings"
+)
+
+// canonicalBudgetPhrases are GitHub's exact wording for a job that never
+// started because an Actions budget / spending-limit block kicked in. They
+// are specific enough that finding them anywhere in a check run -- including
+// its free-form output, which carries job logs -- reliably means a budget
+// block rather than a genuine failure. The canonical annotation reads:
+//
+//	"The job was not started because an Actions budget is preventing further use."
+var canonicalBudgetPhrases = []string{
+	"actions budget is preventing further use",
+	"the job was not started because an actions budget",
+}
+
+// spendingLimitPhrases are broader spending-limit phrases GitHub uses for
+// personal accounts and organizations. They are deliberately only matched
+// against check run annotations -- GitHub's authoritative location for the
+// block notice -- because a genuine failure's logs could legitimately mention
+// a "spending limit" and we must never reclassify a real failure as a budget
+// block (that would silently hide it from the rescue path).
+var spendingLimitPhrases = []string{
+	"spending limit",
+	"spending-limit",
+}
+
+func containsAnyFold(msg string, phrases []string) bool {
+	if msg == "" {
+		return false
+	}
+	lower := strings.ToLower(msg)
+	for _, phrase := range phrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+// isBudgetBlockMessage reports whether msg looks like a GitHub Actions
+// budget / spending-limit block (a job that never started because billing
+// quota was exhausted), as opposed to a real CI failure. It matches the full
+// phrase set and is intended for annotation messages.
+func isBudgetBlockMessage(msg string) bool {
+	return containsAnyFold(msg, canonicalBudgetPhrases) || containsAnyFold(msg, spendingLimitPhrases)
+}
+
+// isBudgetBlockOutput reports whether a check run's output fields or
+// annotation messages indicate a budget/spending-limit block. Output fields
+// (title/summary/text) carry job logs, so only the unambiguous canonical
+// wording is trusted there; the broader spending-limit phrases are trusted
+// only in annotations. It is a pure helper so the classification can be
+// exercised without hitting the GitHub API: the processor gathers the output
+// strings and annotation messages and delegates the decision here.
+func isBudgetBlockOutput(title, summary, text string, annotationMessages []string) bool {
+	if containsAnyFold(title, canonicalBudgetPhrases) ||
+		containsAnyFold(summary, canonicalBudgetPhrases) ||
+		containsAnyFold(text, canonicalBudgetPhrases) {
+		return true
+	}
+	for _, m := range annotationMessages {
+		if isBudgetBlockMessage(m) {
+			return true
+		}
+	}
+	return false
+}
+
+// blockedDetail builds a human-readable detail string for a PR whose CI
+// could not run because of an Actions budget block, naming the affected
+// checks when available. It mirrors failureDetail so the two buckets read
+// consistently in the summary.
+func blockedDetail(blockedChecks []string) string {
+	if len(blockedChecks) == 0 {
+		return "Actions budget exhausted; no jobs ran"
+	}
+	const maxShow = 3
+	if len(blockedChecks) <= maxShow {
+		return fmt.Sprintf("Actions budget exhausted; no jobs ran: %s", strings.Join(blockedChecks, ", "))
+	}
+	return fmt.Sprintf("Actions budget exhausted; no jobs ran: %s (+%d more)",
+		strings.Join(blockedChecks[:maxShow], ", "), len(blockedChecks)-maxShow)
+}

--- a/internal/process/budget.go
+++ b/internal/process/budget.go
@@ -5,13 +5,27 @@ import (
 	"strings"
 )
 
-// Detection is based on the messages GitHub actually emits when a job is
+// Detection is based on the message GitHub actually emits when a job is
 // blocked before it can start because of a billing / Actions-budget /
-// spending-limit problem. Real-world examples (verified against GitHub
-// documentation and reported incidents -- the conclusion is `failure` or
-// `startup_failure`, and the text is surfaced as a failure-level annotation):
+// spending-limit problem.
 //
-//	"The job was not started because an Actions budget is preventing further use."
+// Verified against the live GitHub API (GET .../check-runs and its
+// /annotations) on a real budget-blocked PR. The observed shape is:
+//
+//	check run: status "completed", conclusion "failure",
+//	           output.title/summary/text all null, output.annotations_count 1
+//	annotation: annotation_level "failure", path ".github", title "",
+//	            message "The job was not started because an Actions budget is preventing further use."
+//
+// So the message is carried in the check run's *annotation message*, not its
+// output fields, and the conclusion is "failure" (we also accept
+// "startup_failure"/"timed_out"/"cancelled" defensively). We still scan the
+// output fields too, in case other block variants populate them.
+//
+// Two further variants are reported in the wild for failed payments and
+// locked accounts (not reproducible here, so not API-verified, but handled by
+// the shared prefix below):
+//
 //	"The job was not started because recent account payments have failed or your
 //	 spending limit needs to be increased. ..."
 //	"The job was not started because your account is locked due to a billing issue."

--- a/internal/process/budget.go
+++ b/internal/process/budget.go
@@ -5,61 +5,84 @@ import (
 	"strings"
 )
 
-// canonicalBudgetPhrases are GitHub's exact wording for a job that never
-// started because an Actions budget / spending-limit block kicked in. They
-// are specific enough that finding them anywhere in a check run -- including
-// its free-form output, which carries job logs -- reliably means a budget
-// block rather than a genuine failure. The canonical annotation reads:
+// Detection is based on the messages GitHub actually emits when a job is
+// blocked before it can start because of a billing / Actions-budget /
+// spending-limit problem. Real-world examples (verified against GitHub
+// documentation and reported incidents -- the conclusion is `failure` or
+// `startup_failure`, and the text is surfaced as a failure-level annotation):
 //
 //	"The job was not started because an Actions budget is preventing further use."
-var canonicalBudgetPhrases = []string{
+//	"The job was not started because recent account payments have failed or your
+//	 spending limit needs to be increased. ..."
+//	"The job was not started because your account is locked due to a billing issue."
+//
+// The constant signal across every variant is the platform prefix
+// "job was not started because": GitHub uses it for jobs that never reach the
+// runner, and a genuine test/build/lint failure never produces it. We treat
+// that prefix as the high-confidence anchor and require a billing marker
+// alongside it so unrelated "job was not started" reasons (e.g. concurrency
+// cancellation) are not misread as a budget block.
+
+// jobNotStartedPhrase is the platform-level prefix GitHub uses for a job that
+// never started. On its own it is not necessarily billing-related, so it is
+// only treated as a budget block when paired with a billingMarker.
+const jobNotStartedPhrase = "job was not started because"
+
+// standaloneBudgetPhrases are unambiguous on their own: they cannot plausibly
+// appear in a genuine CI failure, so finding one anywhere is sufficient.
+var standaloneBudgetPhrases = []string{
 	"actions budget is preventing further use",
-	"the job was not started because an actions budget",
 }
 
-// spendingLimitPhrases are broader spending-limit phrases GitHub uses for
-// personal accounts and organizations. They are deliberately only matched
-// against check run annotations -- GitHub's authoritative location for the
-// block notice -- because a genuine failure's logs could legitimately mention
-// a "spending limit" and we must never reclassify a real failure as a budget
-// block (that would silently hide it from the rescue path).
-var spendingLimitPhrases = []string{
+// billingMarkers indicate a billing / budget / spending-limit cause. They are
+// only trusted in combination with jobNotStartedPhrase, because words like
+// "billing" or "payment" can legitimately appear in a real failure's output
+// (e.g. a billing service's failing tests) and must never on their own cause
+// a genuine failure to be hidden from the rescue path.
+var billingMarkers = []string{
+	"budget",
 	"spending limit",
 	"spending-limit",
+	"billing",
+	"payment",
 }
 
-func containsAnyFold(msg string, phrases []string) bool {
+// isBudgetBlockMessage reports whether msg looks like a GitHub job that was
+// blocked before starting because of a billing / Actions-budget /
+// spending-limit problem, as opposed to a real CI failure. A match requires
+// either an unambiguous standalone phrase, or the "job was not started
+// because" prefix together with a billing marker.
+func isBudgetBlockMessage(msg string) bool {
 	if msg == "" {
 		return false
 	}
 	lower := strings.ToLower(msg)
-	for _, phrase := range phrases {
+	for _, phrase := range standaloneBudgetPhrases {
 		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	if !strings.Contains(lower, jobNotStartedPhrase) {
+		return false
+	}
+	for _, marker := range billingMarkers {
+		if strings.Contains(lower, marker) {
 			return true
 		}
 	}
 	return false
 }
 
-// isBudgetBlockMessage reports whether msg looks like a GitHub Actions
-// budget / spending-limit block (a job that never started because billing
-// quota was exhausted), as opposed to a real CI failure. It matches the full
-// phrase set and is intended for annotation messages.
-func isBudgetBlockMessage(msg string) bool {
-	return containsAnyFold(msg, canonicalBudgetPhrases) || containsAnyFold(msg, spendingLimitPhrases)
-}
-
-// isBudgetBlockOutput reports whether a check run's output fields or
-// annotation messages indicate a budget/spending-limit block. Output fields
-// (title/summary/text) carry job logs, so only the unambiguous canonical
-// wording is trusted there; the broader spending-limit phrases are trusted
-// only in annotations. It is a pure helper so the classification can be
-// exercised without hitting the GitHub API: the processor gathers the output
-// strings and annotation messages and delegates the decision here.
+// isBudgetBlockOutput reports whether any of a check run's output fields or
+// annotation messages indicate a budget / billing block. Because
+// isBudgetBlockMessage already anchors on the platform "job was not started
+// because" prefix (or an unambiguous standalone phrase), it is safe to apply
+// uniformly to the free-form output fields and the annotations alike. It is a
+// pure helper so the classification can be exercised without hitting the
+// GitHub API: the processor gathers the output strings and annotation
+// messages and delegates the decision here.
 func isBudgetBlockOutput(title, summary, text string, annotationMessages []string) bool {
-	if containsAnyFold(title, canonicalBudgetPhrases) ||
-		containsAnyFold(summary, canonicalBudgetPhrases) ||
-		containsAnyFold(text, canonicalBudgetPhrases) {
+	if isBudgetBlockMessage(title) || isBudgetBlockMessage(summary) || isBudgetBlockMessage(text) {
 		return true
 	}
 	for _, m := range annotationMessages {

--- a/internal/process/budget.go
+++ b/internal/process/budget.go
@@ -5,9 +5,8 @@ import (
 	"strings"
 )
 
-// Detection is based on the message GitHub actually emits when a job is
-// blocked before it can start because of a billing / Actions-budget /
-// spending-limit problem.
+// Detection matches the single message GitHub actually emits when a job is
+// refused before it can start because an Actions budget is exhausted.
 //
 // Verified against the live GitHub API (GET .../check-runs and its
 // /annotations) on a real budget-blocked PR. The observed shape is:
@@ -20,67 +19,29 @@ import (
 // So the message is carried in the check run's *annotation message*, not its
 // output fields, and the conclusion is "failure" (we also accept
 // "startup_failure"/"timed_out"/"cancelled" defensively). We still scan the
-// output fields too, in case other block variants populate them.
+// output fields too, in case a future variant populates them.
 //
-// Two further variants are reported in the wild for failed payments and
-// locked accounts (not reproducible here, so not API-verified, but handled by
-// the shared prefix below):
-//
-//	"The job was not started because recent account payments have failed or your
-//	 spending limit needs to be increased. ..."
-//	"The job was not started because your account is locked due to a billing issue."
-//
-// The constant signal across every variant is the platform prefix
-// "job was not started because": GitHub uses it for jobs that never reach the
-// runner, and a genuine test/build/lint failure never produces it. We treat
-// that prefix as the high-confidence anchor and require a billing marker
-// alongside it so unrelated "job was not started" reasons (e.g. concurrency
-// cancellation) are not misread as a budget block.
+// Only this API-verified wording is matched. No unverified billing / payment /
+// spending-limit variants are assumed, so any unrecognized block degrades to
+// the normal Failed path rather than risking a real failure being hidden.
 
-// jobNotStartedPhrase is the platform-level prefix GitHub uses for a job that
-// never started. On its own it is not necessarily billing-related, so it is
-// only treated as a budget block when paired with a billingMarker.
-const jobNotStartedPhrase = "job was not started because"
-
-// standaloneBudgetPhrases are unambiguous on their own: they cannot plausibly
-// appear in a genuine CI failure, so finding one anywhere is sufficient.
-var standaloneBudgetPhrases = []string{
+// budgetBlockPhrases are case-insensitive substrings that unambiguously
+// identify an Actions budget block. They cannot plausibly appear in a genuine
+// test/build/lint failure, so finding one anywhere is sufficient.
+var budgetBlockPhrases = []string{
 	"actions budget is preventing further use",
 }
 
-// billingMarkers indicate a billing / budget / spending-limit cause. They are
-// only trusted in combination with jobNotStartedPhrase, because words like
-// "billing" or "payment" can legitimately appear in a real failure's output
-// (e.g. a billing service's failing tests) and must never on their own cause
-// a genuine failure to be hidden from the rescue path.
-var billingMarkers = []string{
-	"budget",
-	"spending limit",
-	"spending-limit",
-	"billing",
-	"payment",
-}
-
-// isBudgetBlockMessage reports whether msg looks like a GitHub job that was
-// blocked before starting because of a billing / Actions-budget /
-// spending-limit problem, as opposed to a real CI failure. A match requires
-// either an unambiguous standalone phrase, or the "job was not started
-// because" prefix together with a billing marker.
+// isBudgetBlockMessage reports whether msg is the GitHub "Actions budget"
+// block message (a job refused before starting because the budget was
+// exhausted), as opposed to a real CI failure.
 func isBudgetBlockMessage(msg string) bool {
 	if msg == "" {
 		return false
 	}
 	lower := strings.ToLower(msg)
-	for _, phrase := range standaloneBudgetPhrases {
+	for _, phrase := range budgetBlockPhrases {
 		if strings.Contains(lower, phrase) {
-			return true
-		}
-	}
-	if !strings.Contains(lower, jobNotStartedPhrase) {
-		return false
-	}
-	for _, marker := range billingMarkers {
-		if strings.Contains(lower, marker) {
 			return true
 		}
 	}
@@ -88,13 +49,11 @@ func isBudgetBlockMessage(msg string) bool {
 }
 
 // isBudgetBlockOutput reports whether any of a check run's output fields or
-// annotation messages indicate a budget / billing block. Because
-// isBudgetBlockMessage already anchors on the platform "job was not started
-// because" prefix (or an unambiguous standalone phrase), it is safe to apply
-// uniformly to the free-form output fields and the annotations alike. It is a
-// pure helper so the classification can be exercised without hitting the
-// GitHub API: the processor gathers the output strings and annotation
-// messages and delegates the decision here.
+// annotation messages indicate an Actions budget block. The verified message
+// lives in the annotation, but the output fields are scanned too as a cheap
+// defensive measure. It is a pure helper so the classification can be
+// exercised without hitting the GitHub API: the processor gathers the output
+// strings and annotation messages and delegates the decision here.
 func isBudgetBlockOutput(title, summary, text string, annotationMessages []string) bool {
 	if isBudgetBlockMessage(title) || isBudgetBlockMessage(summary) || isBudgetBlockMessage(text) {
 		return true

--- a/internal/process/budget_test.go
+++ b/internal/process/budget_test.go
@@ -8,29 +8,40 @@ func TestIsBudgetBlockMessage(t *testing.T) {
 		msg  string
 		want bool
 	}{
+		// Real messages GitHub emits for a job blocked before it starts.
 		{
-			name: "canonical job-not-started annotation",
-			msg:  "The job was not started because an Actions budget is preventing further use.",
+			name: "actions budget variant",
+			msg:  "The job was not started because an Actions budget is preventing further use. This job failed",
 			want: true,
 		},
 		{
-			name: "actions budget phrase case-insensitive",
+			name: "failed payments / spending limit variant",
+			msg:  "The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings",
+			want: true,
+		},
+		{
+			name: "account locked / billing issue variant",
+			msg:  "The job was not started because your account is locked due to a billing issue.",
+			want: true,
+		},
+		{
+			name: "standalone actions-budget phrase case-insensitive",
 			msg:  "ACTIONS BUDGET IS PREVENTING FURTHER USE",
 			want: true,
 		},
+		// The "job was not started because" prefix alone is not enough: it must
+		// be paired with a billing marker, so unrelated job-init reasons stay
+		// out of the budget bucket.
 		{
-			name: "spending limit wording",
-			msg:  "The spending limit for this account has been reached.",
-			want: true,
+			name: "job not started for a non-billing reason does not match",
+			msg:  "The job was not started because the run was canceled",
+			want: false,
 		},
+		// A genuine failure whose text merely mentions billing words must not be
+		// reclassified -- that would hide a real failure from the rescue path.
 		{
-			name: "hyphenated spending-limit",
-			msg:  "Account spending-limit exceeded",
-			want: true,
-		},
-		{
-			name: "generic billing wording no longer matches",
-			msg:  "There is a billing problem with your account",
+			name: "genuine failure mentioning billing words does not match",
+			msg:  "billing_test.go: expected spending limit 100, got 0",
 			want: false,
 		},
 		{
@@ -91,13 +102,14 @@ func TestIsBudgetBlockOutput(t *testing.T) {
 			want:        true,
 		},
 		{
-			name:        "spending-limit wording is trusted in annotations",
-			annotations: []string{"The spending limit for this account has been reached."},
+			name:        "payments/spending-limit variant in annotation",
+			annotations: []string{"The job was not started because recent account payments have failed or your spending limit needs to be increased."},
 			want:        true,
 		},
 		{
-			name:    "spending-limit wording in output fields is not trusted",
-			summary: "spending limit test: expected the spending limit to be 100",
+			name:    "genuine failure mentioning billing in output does not match",
+			title:   "Tests failed",
+			summary: "billing service: spending limit assertion failed",
 			want:    false,
 		},
 		{

--- a/internal/process/budget_test.go
+++ b/internal/process/budget_test.go
@@ -8,41 +8,35 @@ func TestIsBudgetBlockMessage(t *testing.T) {
 		msg  string
 		want bool
 	}{
-		// Real messages GitHub emits for a job blocked before it starts.
 		{
 			// Exact annotation message captured from the live GitHub API on a
 			// real budget-blocked check run (conclusion "failure", message in
 			// the annotation). Locked in as a regression guard.
-			name: "actions budget variant (API-verified annotation message)",
+			name: "actions budget message (API-verified annotation message)",
 			msg:  "The job was not started because an Actions budget is preventing further use.",
 			want: true,
 		},
 		{
-			name: "actions budget variant with trailing text",
+			name: "actions budget message with trailing text",
 			msg:  "The job was not started because an Actions budget is preventing further use. This job failed",
 			want: true,
 		},
 		{
-			name: "failed payments / spending limit variant",
-			msg:  "The job was not started because recent account payments have failed or your spending limit needs to be increased. Please check the 'Billing & plans' section in your settings",
-			want: true,
-		},
-		{
-			name: "account locked / billing issue variant",
-			msg:  "The job was not started because your account is locked due to a billing issue.",
-			want: true,
-		},
-		{
-			name: "standalone actions-budget phrase case-insensitive",
+			name: "actions budget phrase case-insensitive",
 			msg:  "ACTIONS BUDGET IS PREVENTING FURTHER USE",
 			want: true,
 		},
-		// The "job was not started because" prefix alone is not enough: it must
-		// be paired with a billing marker, so unrelated job-init reasons stay
-		// out of the budget bucket.
+		// Unverified billing/payment/spending-limit wording is intentionally
+		// NOT matched: an unrecognized block degrades to the normal Failed path
+		// rather than risking a real failure being hidden.
 		{
-			name: "job not started for a non-billing reason does not match",
-			msg:  "The job was not started because the run was canceled",
+			name: "unverified spending-limit wording does not match",
+			msg:  "The job was not started because recent account payments have failed or your spending limit needs to be increased.",
+			want: false,
+		},
+		{
+			name: "unverified billing-issue wording does not match",
+			msg:  "The job was not started because your account is locked due to a billing issue.",
 			want: false,
 		},
 		// A genuine failure whose text merely mentions billing words must not be
@@ -107,11 +101,6 @@ func TestIsBudgetBlockOutput(t *testing.T) {
 		{
 			name:        "budget message in annotation",
 			annotations: []string{"some context", budget},
-			want:        true,
-		},
-		{
-			name:        "payments/spending-limit variant in annotation",
-			annotations: []string{"The job was not started because recent account payments have failed or your spending limit needs to be increased."},
 			want:        true,
 		},
 		{

--- a/internal/process/budget_test.go
+++ b/internal/process/budget_test.go
@@ -10,7 +10,15 @@ func TestIsBudgetBlockMessage(t *testing.T) {
 	}{
 		// Real messages GitHub emits for a job blocked before it starts.
 		{
-			name: "actions budget variant",
+			// Exact annotation message captured from the live GitHub API on a
+			// real budget-blocked check run (conclusion "failure", message in
+			// the annotation). Locked in as a regression guard.
+			name: "actions budget variant (API-verified annotation message)",
+			msg:  "The job was not started because an Actions budget is preventing further use.",
+			want: true,
+		},
+		{
+			name: "actions budget variant with trailing text",
 			msg:  "The job was not started because an Actions budget is preventing further use. This job failed",
 			want: true,
 		},

--- a/internal/process/budget_test.go
+++ b/internal/process/budget_test.go
@@ -1,0 +1,160 @@
+package process
+
+import "testing"
+
+func TestIsBudgetBlockMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "canonical job-not-started annotation",
+			msg:  "The job was not started because an Actions budget is preventing further use.",
+			want: true,
+		},
+		{
+			name: "actions budget phrase case-insensitive",
+			msg:  "ACTIONS BUDGET IS PREVENTING FURTHER USE",
+			want: true,
+		},
+		{
+			name: "spending limit wording",
+			msg:  "The spending limit for this account has been reached.",
+			want: true,
+		},
+		{
+			name: "hyphenated spending-limit",
+			msg:  "Account spending-limit exceeded",
+			want: true,
+		},
+		{
+			name: "generic billing wording no longer matches",
+			msg:  "There is a billing problem with your account",
+			want: false,
+		},
+		{
+			name: "real test failure does not match",
+			msg:  "Expected 200 but got 500",
+			want: false,
+		},
+		{
+			name: "lint failure does not match",
+			msg:  "undefined: foo",
+			want: false,
+		},
+		{
+			name: "empty message",
+			msg:  "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBudgetBlockMessage(tt.msg); got != tt.want {
+				t.Errorf("isBudgetBlockMessage(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBudgetBlockOutput(t *testing.T) {
+	const budget = "The job was not started because an Actions budget is preventing further use."
+
+	tests := []struct {
+		name        string
+		title       string
+		summary     string
+		text        string
+		annotations []string
+		want        bool
+	}{
+		{
+			name:  "budget message in title",
+			title: budget,
+			want:  true,
+		},
+		{
+			name:    "budget message in summary",
+			summary: budget,
+			want:    true,
+		},
+		{
+			name: "budget message in text",
+			text: budget,
+			want: true,
+		},
+		{
+			name:        "budget message in annotation",
+			annotations: []string{"some context", budget},
+			want:        true,
+		},
+		{
+			name:        "spending-limit wording is trusted in annotations",
+			annotations: []string{"The spending limit for this account has been reached."},
+			want:        true,
+		},
+		{
+			name:    "spending-limit wording in output fields is not trusted",
+			summary: "spending limit test: expected the spending limit to be 100",
+			want:    false,
+		},
+		{
+			name:        "genuine failure annotations do not match",
+			title:       "Tests failed",
+			annotations: []string{"assertion failed", "exit code 1"},
+			want:        false,
+		},
+		{
+			name: "all empty",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isBudgetBlockOutput(tt.title, tt.summary, tt.text, tt.annotations)
+			if got != tt.want {
+				t.Errorf("isBudgetBlockOutput() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlockedDetail(t *testing.T) {
+	tests := []struct {
+		name          string
+		blockedChecks []string
+		want          string
+	}{
+		{
+			name:          "no checks",
+			blockedChecks: nil,
+			want:          "Actions budget exhausted; no jobs ran",
+		},
+		{
+			name:          "one check",
+			blockedChecks: []string{"Test"},
+			want:          "Actions budget exhausted; no jobs ran: Test",
+		},
+		{
+			name:          "three checks",
+			blockedChecks: []string{"Test", "Lint", "Frontend"},
+			want:          "Actions budget exhausted; no jobs ran: Test, Lint, Frontend",
+		},
+		{
+			name:          "more than three checks",
+			blockedChecks: []string{"Test", "Lint", "Frontend", "backend"},
+			want:          "Actions budget exhausted; no jobs ran: Test, Lint, Frontend (+1 more)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := blockedDetail(tt.blockedChecks); got != tt.want {
+				t.Errorf("blockedDetail(%v) = %q, want %q", tt.blockedChecks, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -116,25 +116,32 @@ func (p *Processor) ProcessPR(ctx context.Context, info pr.PRInfo, status *pr.PR
 func (p *Processor) waitForChecks(ctx context.Context, info pr.PRInfo, status *pr.PRStatus, idx int) error {
 	deadline := time.After(checkPollTimeout)
 	for {
-		state, failedChecks, err := p.getCombinedCheckState(ctx, info)
+		outcome, err := p.getCombinedCheckState(ctx, info)
 		if err != nil {
 			status.Update(idx, pr.StatusFailed, ghErrorDetail("check error", err))
 			return err
 		}
 
-		switch state {
+		switch outcome.state {
 		case "success":
 			return nil
+		case "blocked":
+			// CI never ran because a GitHub Actions budget / spending-limit
+			// block prevented every job from starting. This is not a code
+			// failure, so surface it under a distinct status and keep it out
+			// of the rescue path.
+			status.Update(idx, pr.StatusBlockedCI, blockedDetail(outcome.blockedChecks))
+			return fmt.Errorf("ci unavailable: actions budget")
 		case "failure", "error":
-			if name := classifySecurityFailure(failedChecks, p.securityPatterns()); name != "" {
+			if name := classifySecurityFailure(outcome.failedChecks, p.securityPatterns()); name != "" {
 				status.Update(idx, pr.StatusFailedSecurity, fmt.Sprintf("security check failed: %s", name))
 			} else {
-				status.Update(idx, pr.StatusFailed, failureDetail(failedChecks))
+				status.Update(idx, pr.StatusFailed, failureDetail(outcome.failedChecks))
 			}
 			return fmt.Errorf("checks failed")
 		}
 
-		status.Update(idx, pr.StatusChecking, state)
+		status.Update(idx, pr.StatusChecking, outcome.state)
 
 		select {
 		case <-ctx.Done():
@@ -148,10 +155,21 @@ func (p *Processor) waitForChecks(ctx context.Context, info pr.PRInfo, status *p
 	}
 }
 
-func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (string, []string, error) {
+// checkOutcome is the result of evaluating a PR's combined commit status and
+// check runs. failedChecks holds genuine failures; blockedChecks holds checks
+// that failed solely because a GitHub Actions budget block kept the job from
+// starting. The two are tracked separately so a billing block is never
+// reported as a real CI failure.
+type checkOutcome struct {
+	state         string
+	failedChecks  []string
+	blockedChecks []string
+}
+
+func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (checkOutcome, error) {
 	combined, _, err := p.Client.Repositories.GetCombinedStatus(ctx, info.Owner, info.Repo, fmt.Sprintf("refs/pull/%d/head", info.Number), nil)
 	if err != nil {
-		return "", nil, err
+		return checkOutcome{}, err
 	}
 
 	combinedState := combined.GetState()
@@ -159,15 +177,16 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	// Also check check-runs (GitHub Actions use check runs, not commit statuses)
 	checkRuns, _, err := p.Client.Checks.ListCheckRunsForRef(ctx, info.Owner, info.Repo, fmt.Sprintf("refs/pull/%d/head", info.Number), nil)
 	if err != nil {
-		return "", nil, err
+		return checkOutcome{}, err
 	}
 
 	if checkRuns.GetTotal() == 0 && len(combined.Statuses) == 0 {
 		// No checks configured -- treat as success
-		return "success", nil, nil
+		return checkOutcome{state: "success"}, nil
 	}
 
 	var failedChecks []string
+	var blockedChecks []string
 	allComplete := true
 	hasFailure := false
 	for _, cr := range checkRuns.CheckRuns {
@@ -176,9 +195,20 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 			continue
 		}
 		conclusion := cr.GetConclusion()
-		if conclusion == "failure" || conclusion == "timed_out" || conclusion == "cancelled" {
+		if conclusion == "failure" || conclusion == "startup_failure" || conclusion == "timed_out" || conclusion == "cancelled" {
+			name := cr.GetName()
+			// A job that never started because of an Actions budget /
+			// spending-limit block is not a real failure -- route it to the
+			// blocked bucket instead so it is surfaced separately and kept
+			// out of the rescue path.
+			if p.isBudgetBlockedCheckRun(ctx, info, cr) {
+				if name != "" {
+					blockedChecks = append(blockedChecks, name)
+				}
+				continue
+			}
 			hasFailure = true
-			if name := cr.GetName(); name != "" {
+			if name != "" {
 				failedChecks = append(failedChecks, name)
 			}
 		}
@@ -194,19 +224,55 @@ func (p *Processor) getCombinedCheckState(ctx context.Context, info pr.PRInfo) (
 	}
 
 	if hasFailure {
-		return "failure", failedChecks, nil
+		return checkOutcome{state: "failure", failedChecks: failedChecks, blockedChecks: blockedChecks}, nil
 	}
 	if !allComplete {
-		return "pending", nil, nil
+		return checkOutcome{state: "pending"}, nil
 	}
 	if combinedState == "failure" || combinedState == "error" {
-		return combinedState, failedChecks, nil
+		return checkOutcome{state: combinedState, failedChecks: failedChecks, blockedChecks: blockedChecks}, nil
+	}
+	// Every failing check was a budget block and nothing genuinely failed:
+	// the PR's CI could not run at all.
+	if len(blockedChecks) > 0 {
+		return checkOutcome{state: "blocked", blockedChecks: blockedChecks}, nil
 	}
 	if combinedState == "pending" && len(combined.Statuses) > 0 {
-		return "pending", nil, nil
+		return checkOutcome{state: "pending"}, nil
 	}
 
-	return "success", nil, nil
+	return checkOutcome{state: "success"}, nil
+}
+
+// isBudgetBlockedCheckRun reports whether a failed check run failed only
+// because a GitHub Actions budget / spending-limit block prevented the job
+// from starting. It inspects the check run's output fields first (cheap, no
+// extra request) and falls back to fetching the run's annotations, which is
+// where GitHub records the "job was not started because an Actions budget is
+// preventing further use" message. Annotation-fetch errors are treated as
+// "not a budget block" so a transient API error never hides a real failure.
+func (p *Processor) isBudgetBlockedCheckRun(ctx context.Context, info pr.PRInfo, cr *github.CheckRun) bool {
+	out := cr.GetOutput()
+	title := out.GetTitle()
+	summary := out.GetSummary()
+	text := out.GetText()
+	if isBudgetBlockOutput(title, summary, text, nil) {
+		return true
+	}
+
+	if out.GetAnnotationsCount() == 0 {
+		return false
+	}
+
+	annotations, _, err := p.Client.Checks.ListCheckRunAnnotations(ctx, info.Owner, info.Repo, cr.GetID(), nil)
+	if err != nil {
+		return false
+	}
+	messages := make([]string, 0, len(annotations))
+	for _, a := range annotations {
+		messages = append(messages, a.GetMessage())
+	}
+	return isBudgetBlockOutput("", "", "", messages)
 }
 
 // securityPatterns returns the normalized security-check pattern list to


### PR DESCRIPTION
## Summary

When a GitHub Actions budget is exhausted, GitHub refuses to start a PR's jobs and the checks report `failure` even though the code is fine. Treating these as ordinary CI failures sent them down the rescue path, which is wrong -- the remedy is to raise or await the Actions budget, not to touch the code.

This PR adds a distinct `StatusBlockedCI` state and surfaces such PRs separately:

- New `StatusBlockedCI` state, with its own label, magenta color, summary count, and `BlockedEntries()` accessor.
- Budget-blocked PRs are counted, summarised, and surfaced under a dedicated **CI unavailable (Actions budget)** section in both the CLI (`marge sweep`) and the MCP `SweepResult` (`ci_unavailable`). They are kept out of `action_required` and the `failed` count.
- A PR that mixes a genuine failure with a budget block is still reported as **Failed**.
- `Summary()` and `FormatSummary()` share a single `countsLocked()` helper (removes a duplicated counting switch).

## Detection (verified against the live GitHub API)

I captured the real shape of a budget-blocked check run from the GitHub API on an actual blocked PR:

- `conclusion`: **`failure`** (status `completed`)
- `output.title` / `output.summary` / `output.text`: **`null`**
- `output.annotations_count`: **1**
- annotation: `annotation_level: "failure"`, `path: ".github"`, `title: ""`, `message: "The job was not started because an Actions budget is preventing further use."`

So the message is carried in the check run's **annotation `message`**, not its output fields, and the conclusion is `failure`. The detector fetches each failed check run's annotations and matches that single, API-verified message (the output fields are also scanned defensively; conclusions `startup_failure`/`timed_out`/`cancelled` are accepted in addition to `failure`).

Detection matches **only** this verified message. Earlier drafts speculated about failed-payment / locked-account / spending-limit wording; those unverified variants (and the prefix+marker machinery that existed only to catch them) have been removed. Any unrecognized block degrades to the normal `Failed` path rather than risking a real failure being hidden.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` -- includes the exact API-verified annotation message as a regression lock, the case-insensitive match, false-positive guards (a genuine failure mentioning billing/spending words is not matched), disjoint failed/CI-unavailable counts, blocked-not-in-action-required, distinct color, summary wording
- [x] Verified end-to-end against a real blocked PR's API data: 0 commit statuses + all check runs budget-blocked `failure` -> `getCombinedCheckState` returns `blocked` -> `StatusBlockedCI`