### PR TITLE
Add PR age highlighting and ai-rescue markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /marge
 /dist/
 /scripts/
+/graphify-out/

--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ When **every** failing check on a PR is such a block, marge classifies the PR as
 
 > Only this API-verified message is matched; any unrecognized block degrades to the normal `Failed` path rather than risking a real failure being hidden.
 
+#### PR age highlighting
+
+Every table and report includes an **Age** column showing how long the PR has been open (`5h`, `3d`, `2w`). PRs older than 3 days are highlighted yellow, older than 7 days red -- an old dependency PR has already survived several sweeps and is the most likely to need manual work. Failure sections are sorted oldest-first for the same reason.
+
+#### Rescue markers (prior AI rescue attempts)
+
+When an automated rescue (a coding agent, a CI bot, a human with a script) tries to fix a failing dependency PR and gives up, it can record that attempt as a machine-readable **ai-rescue marker** inside an ordinary PR comment:
+
+```markdown
+**AI rescue failed** (klaus): nock v14 is ESM-only and breaks Jest CJS resolution.
+
+<!-- ai-rescue: {"tool":"klaus","outcome":"failed","reason":"ESM-only breaks Jest CJS","head_sha":"d9f00bf2","at":"2026-06-09T18:40:00Z"} -->
+```
+
+On every sweep, marge reads the comments of each failing PR and annotates its entry with the most recent marker, e.g. `[rescue failed 1d ago (klaus): ESM-only breaks Jest CJS]`. The marker records the head SHA it was attempted against: when the PR branch is later rebased or gets a new version, the marker is reported as **stale** (`[rescue failed 3d ago (klaus), stale: new commits since]`) -- the attempt no longer describes the current code and the PR is fair game for another rescue.
+
+This makes the daily triage call obvious at a glance:
+
+- **failing + fresh failed rescue** -> automation already lost; a human is needed
+- **failing + stale or no marker** -> dispatch (another) automated rescue
+
+Use [`marge mark`](#marge-mark-pr-url-flags) to write markers without knowing the format. Any tool that can comment on a PR can participate -- there is no coupling to a specific agent framework.
+
 ### `marge sweep [flags]`
 
 Processes all matching PRs without interactive grouping. After processing, prints a **Security failures** section, an **Action required** section listing any PRs that failed, have conflicts, or came from untrusted authors, and a **CI unavailable (Actions budget)** section for PRs whose checks never ran because an Actions spending limit was exhausted. Security failures (e.g. govulncheck, Trivy, CodeQL) are separated so they are not mistaken for ordinary CI flakiness, and budget-blocked PRs are separated so they are not mistaken for genuine failures (see [CI unavailable (Actions budget)](#ci-unavailable-actions-budget)).
@@ -110,6 +133,30 @@ Processes all matching PRs without interactive grouping. After processing, print
 | `--merge-auto` | | `false` | Also merge PRs that have auto-merge enabled (by default these are skipped) |
 | `--trusted-authors` | | `renovate[bot],dependabot[bot]` | Comma-separated list of trusted PR author logins |
 | `--security-patterns` | | _(built-in)_ | Override the built-in security check pattern list (see [Security check patterns](#security-check-patterns)) |
+
+### `marge mark <pr-url> [flags]`
+
+Records a failed AI rescue attempt on a PR by posting an [ai-rescue marker](#rescue-markers-prior-ai-rescue-attempts) comment. The marker captures the PR's current head SHA, so it automatically goes stale when the branch changes.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--outcome` | `failed` | Rescue outcome: `failed` (attempted, could not fix) or `blocked` (fix known but waits on something external) |
+| `--reason` | | Short explanation of why the rescue did not succeed |
+| `--tool` | `ai` | Name of the tool/agent that attempted the rescue (e.g. `klaus`) |
+
+```bash
+marge mark https://github.com/my-org/my-repo/pull/42 \
+  --tool klaus --reason "nock v14 is ESM-only, needs Jest ESM migration"
+```
+
+Requires the token to have **Issues: Read & write** (comment) permission in addition to the permissions listed under [Setup](#setup).
+
+### `marge serve`
+
+Starts a stdio MCP server exposing two tools:
+
+- **`sweep`** -- mirrors `marge sweep`, returning structured JSON (`summary`, `merged`, `security_failures`, `action_required`, `ci_unavailable`, `skipped`). Each PR entry includes `created_at`, `age_days`, and -- when a prior rescue attempt was found -- a `rescue` object (`tool`, `outcome`, `reason`, `at`, `stale`). Agent orchestrators should skip `action_required` entries whose rescue is `failed` and not `stale`, and escalate those to a human.
+- **`mark`** -- mirrors `marge mark`, so rescue agents can record their own failed attempts.
 
 ### Other commands
 
@@ -172,7 +219,7 @@ marge sweep --merge-auto
    - Approves the PR if not already approved.
    - If auto-merge is enabled, lets the merge queue handle it (unless `--merge-auto` is set).
    - Otherwise merges via squash.
-5. Displays a live-updating table with columns for repository, dependency, version, author, and status. Use `--no-tui` for plain-text output.
+5. Displays a live-updating table with columns for repository, dependency, version, age, author, and status. Failing entries are annotated with any prior AI rescue attempt found on the PR. Use `--no-tui` for plain-text output.
 
 ## Development
 

--- a/cmd/mark.go
+++ b/cmd/mark.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/google/go-github/v88/github"
+	"github.com/spf13/cobra"
+	gh "github.com/teemow/marge/internal/github"
+	"github.com/teemow/marge/internal/pr"
+)
+
+var markOpts struct {
+	Outcome string
+	Reason  string
+	Tool    string
+}
+
+// validMarkOutcomes are the rescue outcomes a marker may record. "failed"
+// means a rescue was attempted on the current code and could not fix it;
+// "blocked" means the fix is known but waits on something external
+// (upstream release, ecosystem support, budget).
+var validMarkOutcomes = map[string]bool{
+	"failed":  true,
+	"blocked": true,
+}
+
+func init() {
+	markCmd.Flags().StringVar(&markOpts.Outcome, "outcome", "failed", "Rescue outcome: \"failed\" or \"blocked\"")
+	markCmd.Flags().StringVar(&markOpts.Reason, "reason", "", "Short explanation of why the rescue did not succeed")
+	markCmd.Flags().StringVar(&markOpts.Tool, "tool", "ai", "Name of the tool/agent that attempted the rescue (e.g. \"klaus\")")
+
+	rootCmd.AddCommand(markCmd)
+}
+
+var markCmd = &cobra.Command{
+	Use:   "mark <pr-url>",
+	Short: "Record a failed AI rescue attempt on a PR",
+	Long: `Post a machine-readable ai-rescue marker comment on a pull request.
+
+Subsequent sweeps read the marker and annotate the PR's failure entry with
+the prior rescue outcome, so the operator can tell "needs a first rescue"
+apart from "an automated rescue already failed here". The marker records
+the PR's current head SHA; when the branch is later rebased or updated,
+the marker is reported as stale and the PR becomes fair game again.
+
+Any tool that can comment on a PR can write the marker -- this command is
+a convenience so callers do not need to know the marker format.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+		defer cancel()
+
+		client, err := gh.NewClient(ctx)
+		if err != nil {
+			return err
+		}
+
+		marker, owner, repo, number, err := markRescue(ctx, client, args[0], markOpts.Outcome, markOpts.Reason, markOpts.Tool)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Marked %s/%s#%d: rescue %s (head %.8s)\n", owner, repo, number, marker.Outcome, marker.HeadSHA)
+		return nil
+	},
+}
+
+// markRescue posts an ai-rescue marker comment on the PR and returns the
+// marker that was written. Shared by the CLI command and the MCP tool.
+func markRescue(ctx context.Context, client *github.Client, prURL, outcome, reason, tool string) (*pr.RescueMarker, string, string, int, error) {
+	outcome = strings.ToLower(strings.TrimSpace(outcome))
+	if !validMarkOutcomes[outcome] {
+		return nil, "", "", 0, fmt.Errorf("invalid outcome %q (must be \"failed\" or \"blocked\")", outcome)
+	}
+
+	owner, repo, number, err := pr.ParsePRURL(prURL)
+	if err != nil {
+		return nil, "", "", 0, err
+	}
+
+	pullReq, _, err := client.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		return nil, "", "", 0, fmt.Errorf("fetching PR: %w", err)
+	}
+
+	marker := &pr.RescueMarker{
+		Tool:    tool,
+		Outcome: outcome,
+		Reason:  reason,
+		HeadSHA: pullReq.GetHead().GetSHA(),
+		At:      time.Now().UTC().Truncate(time.Second),
+	}
+
+	body := marker.CommentBody()
+	_, _, err = client.Issues.CreateComment(ctx, owner, repo, number, &github.IssueComment{Body: &body})
+	if err != nil {
+		return nil, "", "", 0, fmt.Errorf("posting marker comment: %w", err)
+	}
+
+	return marker, owner, repo, number, nil
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -163,12 +163,13 @@ func searchPRs(ctx context.Context, client *github.Client, query string, login s
 					}
 
 					allPRs = append(allPRs, pr.PRInfo{
-						Owner:  owner,
-						Repo:   repo,
-						Number: issue.GetNumber(),
-						Title:  issue.GetTitle(),
-						URL:    url,
-						Author: issue.GetUser().GetLogin(),
+						Owner:     owner,
+						Repo:      repo,
+						Number:    issue.GetNumber(),
+						Title:     issue.GetTitle(),
+						URL:       url,
+						Author:    issue.GetUser().GetLogin(),
+						CreatedAt: issue.GetCreatedAt().Time,
 					})
 				}
 
@@ -213,12 +214,13 @@ func searchPRs(ctx context.Context, client *github.Client, query string, login s
 			}
 
 			allPRs = append(allPRs, pr.PRInfo{
-				Owner:  owner,
-				Repo:   repo,
-				Number: issue.GetNumber(),
-				Title:  title,
-				URL:    url,
-				Author: issue.GetUser().GetLogin(),
+				Owner:     owner,
+				Repo:      repo,
+				Number:    issue.GetNumber(),
+				Title:     title,
+				URL:       url,
+				Author:    issue.GetUser().GetLogin(),
+				CreatedAt: issue.GetCreatedAt().Time,
 			})
 		}
 
@@ -300,12 +302,13 @@ func listRepoPRs(ctx context.Context, client *github.Client, reposFile, query, a
 						continue
 					}
 					batch = append(batch, pr.PRInfo{
-						Owner:  owner,
-						Repo:   name,
-						Number: pull.GetNumber(),
-						Title:  pull.GetTitle(),
-						URL:    url,
-						Author: author,
+						Owner:     owner,
+						Repo:      name,
+						Number:    pull.GetNumber(),
+						Title:     pull.GetTitle(),
+						URL:       url,
+						Author:    author,
+						CreatedAt: pull.GetCreatedAt().Time,
 					})
 				}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -65,6 +66,27 @@ returning structured JSON results instead of terminal output.`,
 			handleSweep,
 		)
 
+		mcpServer.AddTool(
+			mcp.NewTool("mark",
+				mcp.WithDescription("Record a failed AI rescue attempt on a PR by posting a machine-readable ai-rescue marker comment. Subsequent sweeps surface the marker so the operator knows a rescue was already attempted; the marker goes stale automatically when the PR branch is updated."),
+				mcp.WithString("pr_url",
+					mcp.Required(),
+					mcp.Description("Pull request URL (https://github.com/OWNER/REPO/pull/NUMBER)"),
+				),
+				mcp.WithString("outcome",
+					mcp.Description("Rescue outcome (default: \"failed\")"),
+					mcp.Enum("failed", "blocked"),
+				),
+				mcp.WithString("reason",
+					mcp.Description("Short explanation of why the rescue did not succeed"),
+				),
+				mcp.WithString("tool",
+					mcp.Description("Name of the tool/agent that attempted the rescue (default: \"ai\")"),
+				),
+			),
+			handleMark,
+		)
+
 		return server.ServeStdio(mcpServer)
 	},
 }
@@ -102,13 +124,32 @@ type SweepSummary struct {
 
 // SweepPREntry represents a single PR in the sweep results.
 type SweepPREntry struct {
-	Owner  string `json:"owner"`
-	Repo   string `json:"repo"`
-	Number int    `json:"number"`
-	Title  string `json:"title"`
-	URL    string `json:"url"`
-	Status string `json:"status"`
-	Detail string `json:"detail,omitempty"`
+	Owner     string `json:"owner"`
+	Repo      string `json:"repo"`
+	Number    int    `json:"number"`
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	Status    string `json:"status"`
+	Detail    string `json:"detail,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	AgeDays   int    `json:"age_days,omitempty"`
+	// Rescue describes the most recent prior automated rescue attempt
+	// found on the PR (an ai-rescue marker comment), if any. Consumers
+	// dispatching rescue agents should skip entries with a non-stale
+	// failed rescue and escalate them to a human instead.
+	Rescue *SweepRescueInfo `json:"rescue,omitempty"`
+}
+
+// SweepRescueInfo is the JSON projection of a pr.RescueMarker.
+type SweepRescueInfo struct {
+	Tool    string `json:"tool,omitempty"`
+	Outcome string `json:"outcome"`
+	Reason  string `json:"reason,omitempty"`
+	At      string `json:"at,omitempty"`
+	// Stale is true when the PR head moved since the rescue attempt --
+	// the attempt no longer describes the current code and the PR is
+	// fair game for another rescue.
+	Stale bool `json:"stale"`
 }
 
 func handleSweep(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -198,8 +239,9 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 		},
 	}
 
+	now := time.Now()
 	toEntry := func(e pr.StatusEntry) SweepPREntry {
-		return SweepPREntry{
+		entry := SweepPREntry{
 			Owner:  e.PR.Owner,
 			Repo:   e.PR.Repo,
 			Number: e.PR.Number,
@@ -208,6 +250,22 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 			Status: e.State.String(),
 			Detail: e.Detail,
 		}
+		if !e.PR.CreatedAt.IsZero() {
+			entry.CreatedAt = e.PR.CreatedAt.UTC().Format(time.RFC3339)
+			entry.AgeDays = pr.AgeDays(e.PR.CreatedAt, now)
+		}
+		if e.Rescue != nil {
+			entry.Rescue = &SweepRescueInfo{
+				Tool:    e.Rescue.Tool,
+				Outcome: e.Rescue.Outcome,
+				Reason:  e.Rescue.Reason,
+				Stale:   e.Rescue.Stale,
+			}
+			if !e.Rescue.At.IsZero() {
+				entry.Rescue.At = e.Rescue.At.UTC().Format(time.RFC3339)
+			}
+		}
+		return entry
 	}
 
 	for _, e := range status.MergedEntries() {
@@ -234,6 +292,38 @@ func buildSweepResult(status *pr.PRStatus) SweepResult {
 	}
 
 	return result
+}
+
+func handleMark(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	prURL := request.GetString("pr_url", "")
+	outcome := request.GetString("outcome", "failed")
+	reason := request.GetString("reason", "")
+	tool := request.GetString("tool", "ai")
+
+	client, err := gh.NewClient(ctx)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("creating GitHub client: %v", err)), nil
+	}
+
+	marker, owner, repo, number, err := markRescue(ctx, client, prURL, outcome, reason, tool)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	result := map[string]any{
+		"owner":    owner,
+		"repo":     repo,
+		"number":   number,
+		"outcome":  marker.Outcome,
+		"tool":     marker.Tool,
+		"head_sha": marker.HeadSHA,
+		"at":       marker.At.Format(time.RFC3339),
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("marshaling result: %v", err)), nil
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
 }
 
 func createTempReposFile(repos []string) (string, error) {

--- a/cmd/sweep.go
+++ b/cmd/sweep.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	gh "github.com/teemow/marge/internal/github"
@@ -92,9 +93,22 @@ func printSweepFailures(w *os.File, header string, entries []pr.StatusEntry) {
 		return
 	}
 	_, _ = fmt.Fprintf(w, "\n%s (%d):\n\n", header, len(entries))
+	now := time.Now()
 	for _, e := range entries {
-		_, _ = fmt.Fprintf(w, "  #%-6d %s/%s\n", e.PR.Number, e.PR.Owner, e.PR.Repo)
+		repoLine := fmt.Sprintf("  #%-6d %s/%s", e.PR.Number, e.PR.Owner, e.PR.Repo)
+		if age := pr.FormatAge(e.PR.CreatedAt, now); age != "" {
+			ageStr := fmt.Sprintf("(%s old)", age)
+			if code := pr.AgeColorCode(e.PR.CreatedAt, now); code != "" {
+				ageStr = code + ageStr + "\033[0m"
+			}
+			repoLine += "  " + ageStr
+		}
+		_, _ = fmt.Fprintln(w, repoLine)
 		_, _ = fmt.Fprintf(w, "         %s\n", e.PR.Title)
-		_, _ = fmt.Fprintf(w, "         %s  %s\n\n", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
+		statusLine := fmt.Sprintf("         %s  %s", e.PR.URL, pr.ColorizeStatus(e.State, e.Detail))
+		if e.Rescue != nil {
+			statusLine += "  " + pr.ColorizeRescue(e.Rescue, now)
+		}
+		_, _ = fmt.Fprintf(w, "%s\n\n", statusLine)
 	}
 }

--- a/internal/pr/age.go
+++ b/internal/pr/age.go
@@ -1,0 +1,79 @@
+package pr
+
+import (
+	"fmt"
+	"time"
+)
+
+// Age thresholds: a PR older than ageWarnAfter is highlighted as aging
+// (yellow); older than ageStaleAfter it is highlighted as stale (red).
+// A dependency PR that has been open for more than a few days has, in
+// practice, already survived at least one automated sweep -- it is the
+// population most likely to need manual work.
+const (
+	ageWarnAfter  = 3 * 24 * time.Hour
+	ageStaleAfter = 7 * 24 * time.Hour
+)
+
+// FormatAge renders the time since created as a compact human string
+// ("5h", "3d", "2w"). It returns "" for a zero creation time so callers
+// can omit the column value when the discovery path did not provide it.
+func FormatAge(created, now time.Time) string {
+	if created.IsZero() {
+		return ""
+	}
+	d := now.Sub(created)
+	if d < 0 {
+		d = 0
+	}
+	days := int(d.Hours() / 24)
+	switch {
+	case days < 1:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	case days < 14:
+		return fmt.Sprintf("%dd", days)
+	default:
+		return fmt.Sprintf("%dw", days/7)
+	}
+}
+
+// AgeDays returns the whole number of days since created, or 0 for a
+// zero creation time.
+func AgeDays(created, now time.Time) int {
+	if created.IsZero() {
+		return 0
+	}
+	d := now.Sub(created)
+	if d < 0 {
+		return 0
+	}
+	return int(d.Hours() / 24)
+}
+
+// AgeColorCode returns the ANSI color prefix for a PR age: "" while the
+// PR is fresh, yellow once it passes ageWarnAfter, red once it passes
+// ageStaleAfter. Callers must reset with \033[0m when non-empty.
+func AgeColorCode(created, now time.Time) string {
+	if created.IsZero() {
+		return ""
+	}
+	age := now.Sub(created)
+	switch {
+	case age >= ageStaleAfter:
+		return "\033[31m" // red
+	case age >= ageWarnAfter:
+		return "\033[33m" // yellow
+	default:
+		return ""
+	}
+}
+
+// AgeInfoFunc is the table-column accessor for the Age column.
+func AgeInfoFunc(p PRInfo) string {
+	return FormatAge(p.CreatedAt, time.Now())
+}
+
+// AgeColorFunc is the table-column color accessor for the Age column.
+func AgeColorFunc(p PRInfo) string {
+	return AgeColorCode(p.CreatedAt, time.Now())
+}

--- a/internal/pr/age_test.go
+++ b/internal/pr/age_test.go
@@ -1,0 +1,85 @@
+package pr
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatAge(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		created time.Time
+		want    string
+	}{
+		{"zero time", time.Time{}, ""},
+		{"five hours", now.Add(-5 * time.Hour), "5h"},
+		{"three days", now.Add(-3 * 24 * time.Hour), "3d"},
+		{"thirteen days stays in days", now.Add(-13 * 24 * time.Hour), "13d"},
+		{"two weeks", now.Add(-14 * 24 * time.Hour), "2w"},
+		{"future clamps to zero", now.Add(2 * time.Hour), "0h"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatAge(tt.created, now); got != tt.want {
+				t.Errorf("FormatAge = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgeColorCode(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	if got := AgeColorCode(time.Time{}, now); got != "" {
+		t.Errorf("zero time = %q, want empty", got)
+	}
+	if got := AgeColorCode(now.Add(-24*time.Hour), now); got != "" {
+		t.Errorf("fresh = %q, want empty", got)
+	}
+	if got := AgeColorCode(now.Add(-4*24*time.Hour), now); got != "\033[33m" {
+		t.Errorf("aging = %q, want yellow", got)
+	}
+	if got := AgeColorCode(now.Add(-8*24*time.Hour), now); got != "\033[31m" {
+		t.Errorf("stale = %q, want red", got)
+	}
+}
+
+func TestAgeDays(t *testing.T) {
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	if got := AgeDays(time.Time{}, now); got != 0 {
+		t.Errorf("zero time = %d, want 0", got)
+	}
+	if got := AgeDays(now.Add(-12*24*time.Hour), now); got != 12 {
+		t.Errorf("twelve days = %d, want 12", got)
+	}
+}
+
+func TestActionRequired_sortedOldestFirst(t *testing.T) {
+	now := time.Now()
+	s := NewPRStatus()
+
+	young := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 2, CreatedAt: now.Add(-1 * 24 * time.Hour)})
+	old := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 1, CreatedAt: now.Add(-10 * 24 * time.Hour)})
+	noDate := s.Add(PRInfo{Owner: "o", Repo: "r", Number: 3})
+
+	s.Update(young, StatusFailed, "")
+	s.Update(old, StatusFailed, "")
+	s.Update(noDate, StatusFailed, "")
+
+	ar := s.ActionRequired()
+	if len(ar) != 3 {
+		t.Fatalf("ActionRequired len = %d, want 3", len(ar))
+	}
+	if ar[0].PR.Number != 1 {
+		t.Errorf("first entry = #%d, want #1 (oldest)", ar[0].PR.Number)
+	}
+	if ar[1].PR.Number != 2 {
+		t.Errorf("second entry = #%d, want #2", ar[1].PR.Number)
+	}
+	if ar[2].PR.Number != 3 {
+		t.Errorf("third entry = #%d, want #3 (no creation date sorts last)", ar[2].PR.Number)
+	}
+}

--- a/internal/pr/grouping.go
+++ b/internal/pr/grouping.go
@@ -3,15 +3,17 @@ package pr
 import (
 	"fmt"
 	"sort"
+	"time"
 )
 
 type PRInfo struct {
-	Owner  string
-	Repo   string
-	Number int
-	Title  string
-	URL    string
-	Author string
+	Owner     string
+	Repo      string
+	Number    int
+	Title     string
+	URL       string
+	Author    string
+	CreatedAt time.Time
 }
 
 type PRGroup struct {

--- a/internal/pr/parse.go
+++ b/internal/pr/parse.go
@@ -3,6 +3,7 @@ package pr
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -14,6 +15,20 @@ func ExtractOwnerRepo(htmlURL string) (string, string, error) {
 		return "", "", fmt.Errorf("unexpected URL format: %s", htmlURL)
 	}
 	return parts[0], parts[1], nil
+}
+
+// ParsePRURL parses owner, repo, and PR number from a GitHub pull request
+// URL (e.g. "https://github.com/OWNER/REPO/pull/123").
+func ParsePRURL(htmlURL string) (owner, repo string, number int, err error) {
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(htmlURL, "https://github.com/"), "/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return "", "", 0, fmt.Errorf("not a pull request URL: %s", htmlURL)
+	}
+	number, err = strconv.Atoi(parts[3])
+	if err != nil {
+		return "", "", 0, fmt.Errorf("invalid PR number in URL %s: %w", htmlURL, err)
+	}
+	return parts[0], parts[1], number, nil
 }
 
 var conventionalCommitPrefixRE = regexp.MustCompile(`(?i)^\w+(\([^)]*\))?:\s*`)

--- a/internal/pr/parse_test.go
+++ b/internal/pr/parse_test.go
@@ -4,6 +4,26 @@ import (
 	"testing"
 )
 
+func TestParsePRURL(t *testing.T) {
+	owner, repo, number, err := ParsePRURL("https://github.com/giantswarm/happa/pull/4808")
+	if err != nil {
+		t.Fatalf("ParsePRURL error: %v", err)
+	}
+	if owner != "giantswarm" || repo != "happa" || number != 4808 {
+		t.Errorf("got %s/%s#%d, want giantswarm/happa#4808", owner, repo, number)
+	}
+
+	for _, bad := range []string{
+		"https://github.com/giantswarm/happa",
+		"https://github.com/giantswarm/happa/issues/42",
+		"https://github.com/giantswarm/happa/pull/abc",
+	} {
+		if _, _, _, err := ParsePRURL(bad); err == nil {
+			t.Errorf("ParsePRURL(%q) expected error, got nil", bad)
+		}
+	}
+}
+
 func TestExtractOwnerRepo(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/pr/rescue.go
+++ b/internal/pr/rescue.go
@@ -1,0 +1,130 @@
+package pr
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// RescueMarker records a prior automated rescue attempt on a PR. It is
+// embedded as a machine-readable HTML comment inside an ordinary PR
+// comment, so any tool that can comment on a PR (a klaus agent, a Cursor
+// agent, a GitHub Action) can participate without coupling to marge:
+//
+//	<!-- ai-rescue: {"tool":"klaus","outcome":"failed","reason":"...","head_sha":"...","at":"2026-06-09T18:40:00Z"} -->
+//
+// HeadSHA ties the attempt to the code it was attempted against. Renovate
+// force-pushes on rebase or version change, so a marker whose head_sha no
+// longer matches the PR head describes code that no longer exists -- the
+// attempt is stale and the PR is fair game for another rescue.
+type RescueMarker struct {
+	Tool    string    `json:"tool,omitempty"`
+	Outcome string    `json:"outcome"`
+	Reason  string    `json:"reason,omitempty"`
+	HeadSHA string    `json:"head_sha,omitempty"`
+	At      time.Time `json:"at,omitempty"`
+
+	// Stale is computed by MarkStale, never serialized into the marker.
+	Stale bool `json:"-"`
+}
+
+var rescueMarkerRE = regexp.MustCompile(`(?s)<!--\s*ai-rescue:\s*(\{.*?\})\s*-->`)
+
+// ParseRescueMarker extracts the last ai-rescue marker from a comment
+// body. It returns nil when the body contains no parseable marker; a
+// malformed JSON payload is ignored rather than treated as an error so a
+// mangled comment can never break a sweep.
+func ParseRescueMarker(body string) *RescueMarker {
+	matches := rescueMarkerRE.FindAllStringSubmatch(body, -1)
+	for i := len(matches) - 1; i >= 0; i-- {
+		var m RescueMarker
+		if err := json.Unmarshal([]byte(matches[i][1]), &m); err != nil {
+			continue
+		}
+		if m.Outcome == "" {
+			continue
+		}
+		return &m
+	}
+	return nil
+}
+
+// MarkStale sets Stale by comparing the marker's recorded head SHA with
+// the PR's current head. Short-vs-full SHA prefixes match. A marker
+// without a recorded SHA cannot be aged out, so it stays non-stale until
+// a newer marker replaces it.
+func (m *RescueMarker) MarkStale(currentHeadSHA string) {
+	if m.HeadSHA == "" || currentHeadSHA == "" {
+		m.Stale = false
+		return
+	}
+	m.Stale = !shaPrefixMatch(m.HeadSHA, currentHeadSHA)
+}
+
+func shaPrefixMatch(a, b string) bool {
+	a, b = strings.ToLower(a), strings.ToLower(b)
+	if len(a) > len(b) {
+		a, b = b, a
+	}
+	return a != "" && strings.HasPrefix(b, a)
+}
+
+// CommentBody renders the full PR comment for this marker: a
+// human-readable summary followed by the machine-readable marker.
+func (m *RescueMarker) CommentBody() string {
+	tool := m.Tool
+	if tool == "" {
+		tool = "ai"
+	}
+	human := fmt.Sprintf("**AI rescue %s** (%s)", m.Outcome, tool)
+	if m.Reason != "" {
+		human += ": " + m.Reason
+	}
+
+	payload, _ := json.Marshal(m)
+	return fmt.Sprintf("%s\n\n<!-- ai-rescue: %s -->", human, payload)
+}
+
+// FormatRescue renders the marker as a short human-readable annotation
+// for status output, e.g. "rescue failed 1d ago (klaus): ESM-only" or
+// "rescue failed 3d ago (klaus), stale: new commits since".
+func FormatRescue(m *RescueMarker, now time.Time) string {
+	if m == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("rescue ")
+	b.WriteString(m.Outcome)
+	if !m.At.IsZero() {
+		b.WriteString(" ")
+		b.WriteString(FormatAge(m.At, now))
+		b.WriteString(" ago")
+	}
+	if m.Tool != "" {
+		fmt.Fprintf(&b, " (%s)", m.Tool)
+	}
+	if m.Stale {
+		b.WriteString(", stale: new commits since")
+	} else if m.Reason != "" {
+		b.WriteString(": ")
+		b.WriteString(m.Reason)
+	}
+	return b.String()
+}
+
+// ColorizeRescue wraps the FormatRescue annotation in ANSI colors: a
+// stale marker renders yellow (retriable -- the code changed since the
+// attempt), a fresh one bold red (a rescue already failed on exactly
+// this code; a human is needed).
+func ColorizeRescue(m *RescueMarker, now time.Time) string {
+	s := FormatRescue(m, now)
+	if s == "" {
+		return ""
+	}
+	if m.Stale {
+		return fmt.Sprintf("\033[33m[%s]\033[0m", s)
+	}
+	return fmt.Sprintf("\033[1;91m[%s]\033[0m", s)
+}

--- a/internal/pr/rescue_test.go
+++ b/internal/pr/rescue_test.go
@@ -1,0 +1,131 @@
+package pr
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRescueMarker(t *testing.T) {
+	body := `Rescue attempt failed: nock v14 is ESM-only and breaks Jest CJS resolution.
+
+<!-- ai-rescue: {"tool":"klaus","outcome":"failed","reason":"ESM-only breaks Jest CJS","head_sha":"d9f00bf2","at":"2026-06-09T18:40:00Z"} -->`
+
+	m := ParseRescueMarker(body)
+	if m == nil {
+		t.Fatal("ParseRescueMarker returned nil")
+	}
+	if m.Tool != "klaus" {
+		t.Errorf("Tool = %q, want %q", m.Tool, "klaus")
+	}
+	if m.Outcome != "failed" {
+		t.Errorf("Outcome = %q, want %q", m.Outcome, "failed")
+	}
+	if m.Reason != "ESM-only breaks Jest CJS" {
+		t.Errorf("Reason = %q", m.Reason)
+	}
+	if m.HeadSHA != "d9f00bf2" {
+		t.Errorf("HeadSHA = %q", m.HeadSHA)
+	}
+	want := time.Date(2026, 6, 9, 18, 40, 0, 0, time.UTC)
+	if !m.At.Equal(want) {
+		t.Errorf("At = %v, want %v", m.At, want)
+	}
+}
+
+func TestParseRescueMarker_noMarker(t *testing.T) {
+	if m := ParseRescueMarker("just a regular comment"); m != nil {
+		t.Errorf("expected nil, got %+v", m)
+	}
+}
+
+func TestParseRescueMarker_malformedJSONIgnored(t *testing.T) {
+	if m := ParseRescueMarker(`<!-- ai-rescue: {not json} -->`); m != nil {
+		t.Errorf("expected nil for malformed JSON, got %+v", m)
+	}
+}
+
+func TestParseRescueMarker_missingOutcomeIgnored(t *testing.T) {
+	if m := ParseRescueMarker(`<!-- ai-rescue: {"tool":"klaus"} -->`); m != nil {
+		t.Errorf("expected nil for marker without outcome, got %+v", m)
+	}
+}
+
+func TestParseRescueMarker_lastMarkerWins(t *testing.T) {
+	body := `<!-- ai-rescue: {"outcome":"failed","reason":"first"} -->
+<!-- ai-rescue: {"outcome":"blocked","reason":"second"} -->`
+
+	m := ParseRescueMarker(body)
+	if m == nil {
+		t.Fatal("ParseRescueMarker returned nil")
+	}
+	if m.Reason != "second" {
+		t.Errorf("Reason = %q, want %q (last marker should win)", m.Reason, "second")
+	}
+}
+
+func TestMarkStale(t *testing.T) {
+	tests := []struct {
+		name      string
+		markerSHA string
+		headSHA   string
+		wantStale bool
+	}{
+		{"same full SHA", "d9f00bf2d90e7dc6b3013a975c08d80766542745", "d9f00bf2d90e7dc6b3013a975c08d80766542745", false},
+		{"short marker SHA matches head prefix", "d9f00bf2", "d9f00bf2d90e7dc6b3013a975c08d80766542745", false},
+		{"different SHA", "d9f00bf2", "edf33f4d1cff7cab190b39689bd3ac77b6bd0910", true},
+		{"marker without SHA never stale", "", "edf33f4d", false},
+		{"unknown current head never stale", "d9f00bf2", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &RescueMarker{Outcome: "failed", HeadSHA: tt.markerSHA}
+			m.MarkStale(tt.headSHA)
+			if m.Stale != tt.wantStale {
+				t.Errorf("Stale = %v, want %v", m.Stale, tt.wantStale)
+			}
+		})
+	}
+}
+
+func TestCommentBody_roundTrips(t *testing.T) {
+	orig := &RescueMarker{
+		Tool:    "klaus",
+		Outcome: "failed",
+		Reason:  "pytest-helm-charts requires pytest<9",
+		HeadSHA: "d9f00bf2",
+		At:      time.Date(2026, 6, 9, 18, 40, 0, 0, time.UTC),
+	}
+
+	body := orig.CommentBody()
+
+	if !strings.Contains(body, "**AI rescue failed** (klaus): pytest-helm-charts requires pytest<9") {
+		t.Errorf("human-readable part missing or wrong:\n%s", body)
+	}
+
+	parsed := ParseRescueMarker(body)
+	if parsed == nil {
+		t.Fatal("CommentBody output did not parse back")
+	}
+	if parsed.Tool != orig.Tool || parsed.Outcome != orig.Outcome || parsed.Reason != orig.Reason || parsed.HeadSHA != orig.HeadSHA || !parsed.At.Equal(orig.At) {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", parsed, orig)
+	}
+}
+
+func TestFormatRescue(t *testing.T) {
+	now := time.Date(2026, 6, 10, 8, 0, 0, 0, time.UTC)
+
+	fresh := &RescueMarker{Tool: "klaus", Outcome: "failed", Reason: "ESM-only", At: now.Add(-25 * time.Hour)}
+	if got := FormatRescue(fresh, now); got != "rescue failed 1d ago (klaus): ESM-only" {
+		t.Errorf("fresh = %q", got)
+	}
+
+	stale := &RescueMarker{Tool: "klaus", Outcome: "failed", Reason: "ESM-only", At: now.Add(-25 * time.Hour), Stale: true}
+	if got := FormatRescue(stale, now); got != "rescue failed 1d ago (klaus), stale: new commits since" {
+		t.Errorf("stale = %q", got)
+	}
+
+	if got := FormatRescue(nil, now); got != "" {
+		t.Errorf("nil = %q, want empty", got)
+	}
+}

--- a/internal/pr/status.go
+++ b/internal/pr/status.go
@@ -2,6 +2,7 @@ package pr
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 )
 
@@ -68,6 +69,9 @@ type StatusEntry struct {
 	PR     PRInfo
 	State  StatusState
 	Detail string
+	// Rescue is the most recent prior automated rescue attempt found on
+	// the PR, if any. Only populated for failure-state entries.
+	Rescue *RescueMarker
 }
 
 func NewPRStatus() *PRStatus {
@@ -92,6 +96,26 @@ func (s *PRStatus) Update(idx int, state StatusState, detail string) {
 		s.entries[idx].State = state
 		s.entries[idx].Detail = detail
 	}
+}
+
+// SetRescue attaches a prior rescue-attempt marker to an entry.
+func (s *PRStatus) SetRescue(idx int, marker *RescueMarker) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < len(s.entries) {
+		s.entries[idx].Rescue = marker
+	}
+}
+
+// StateAt returns the current state of the entry at idx, or
+// StatusPending when idx is out of range.
+func (s *PRStatus) StateAt(idx int) StatusState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if idx < len(s.entries) {
+		return s.entries[idx].State
+	}
+	return StatusPending
 }
 
 func (s *PRStatus) Snapshot() []StatusEntry {
@@ -146,6 +170,10 @@ func (s *PRStatus) FormatSummary() string {
 	return fmt.Sprintf("%d PRs processed: %d merged, %d failed, %d skipped", total, merged, failed, skipped)
 }
 
+// ActionRequired returns the failure entries, oldest PR first: the
+// longer a dependency PR has been open, the more sweeps it has already
+// survived, so the old ones are the most likely to need manual work.
+// Entries without a known creation time sort last, in insertion order.
 func (s *PRStatus) ActionRequired() []StatusEntry {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -156,6 +184,13 @@ func (s *PRStatus) ActionRequired() []StatusEntry {
 			result = append(result, e)
 		}
 	}
+	sort.SliceStable(result, func(i, j int) bool {
+		ci, cj := result[i].PR.CreatedAt, result[j].PR.CreatedAt
+		if ci.IsZero() || cj.IsZero() {
+			return !ci.IsZero()
+		}
+		return ci.Before(cj)
+	})
 	return result
 }
 

--- a/internal/pr/ui.go
+++ b/internal/pr/ui.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -15,6 +16,10 @@ type TableColumn struct {
 	Label string
 	Width int
 	Fn    func(PRInfo) string
+	// Color optionally returns an ANSI color prefix for a value. The
+	// value is padded to Width first, then wrapped, so colored cells
+	// stay aligned with the rest of the table.
+	Color func(PRInfo) string
 }
 
 func RepoInfoFunc(p PRInfo) string {
@@ -37,28 +42,35 @@ func AuthorInfoFunc(p PRInfo) string {
 	return p.Author
 }
 
+func ageColumn() TableColumn {
+	return TableColumn{Label: "Age", Width: 4, Fn: AgeInfoFunc, Color: AgeColorFunc}
+}
+
 func FullColumns() []TableColumn {
 	return []TableColumn{
-		{"Repository", 22, RepoInfoFunc},
-		{"Dependency", 22, DependencyInfoFunc},
-		{"Version", 18, VersionInfoFunc},
-		{"Author", 16, AuthorInfoFunc},
+		{Label: "Repository", Width: 22, Fn: RepoInfoFunc},
+		{Label: "Dependency", Width: 22, Fn: DependencyInfoFunc},
+		{Label: "Version", Width: 18, Fn: VersionInfoFunc},
+		ageColumn(),
+		{Label: "Author", Width: 16, Fn: AuthorInfoFunc},
 	}
 }
 
 func RepoSelectedColumns() []TableColumn {
 	return []TableColumn{
-		{"Dependency", 28, DependencyInfoFunc},
-		{"Version", 18, VersionInfoFunc},
-		{"Author", 16, AuthorInfoFunc},
+		{Label: "Dependency", Width: 28, Fn: DependencyInfoFunc},
+		{Label: "Version", Width: 18, Fn: VersionInfoFunc},
+		ageColumn(),
+		{Label: "Author", Width: 16, Fn: AuthorInfoFunc},
 	}
 }
 
 func DependencySelectedColumns() []TableColumn {
 	return []TableColumn{
-		{"Repository", 28, RepoInfoFunc},
-		{"Version", 18, VersionInfoFunc},
-		{"Author", 16, AuthorInfoFunc},
+		{Label: "Repository", Width: 28, Fn: RepoInfoFunc},
+		{Label: "Version", Width: 18, Fn: VersionInfoFunc},
+		ageColumn(),
+		{Label: "Author", Width: 16, Fn: AuthorInfoFunc},
 	}
 }
 
@@ -95,9 +107,18 @@ func PrintRow(w *os.File, e StatusEntry, cols []TableColumn) {
 	parts := make([]string, 0, len(cols)+2)
 	parts = append(parts, prLink)
 	for _, c := range cols {
-		parts = append(parts, fmt.Sprintf("%-*s", c.Width, truncate(c.Fn(e.PR), c.Width)))
+		cell := fmt.Sprintf("%-*s", c.Width, truncate(c.Fn(e.PR), c.Width))
+		if c.Color != nil {
+			if code := c.Color(e.PR); code != "" {
+				cell = code + cell + "\033[0m"
+			}
+		}
+		parts = append(parts, cell)
 	}
 	parts = append(parts, ColorizeStatus(e.State, e.Detail))
+	if e.Rescue != nil {
+		parts = append(parts, ColorizeRescue(e.Rescue, time.Now()))
+	}
 
 	_, _ = fmt.Fprintf(w, "\033[2K%s\n", strings.Join(parts, " "))
 }
@@ -214,8 +235,16 @@ func printPlainEntry(w *os.File, e StatusEntry) {
 	if ver != "" {
 		verStr = " " + ver
 	}
-	_, _ = fmt.Fprintf(w, "  #%-6d %s/%s  %s%s  [%s] [%s]\n",
-		e.PR.Number, e.PR.Owner, e.PR.Repo, dep, verStr, e.PR.Author, detail)
+	ageStr := ""
+	if age := FormatAge(e.PR.CreatedAt, time.Now()); age != "" {
+		ageStr = fmt.Sprintf(" [%s old]", age)
+	}
+	rescueStr := ""
+	if e.Rescue != nil {
+		rescueStr = fmt.Sprintf(" [%s]", FormatRescue(e.Rescue, time.Now()))
+	}
+	_, _ = fmt.Fprintf(w, "  #%-6d %s/%s  %s%s%s  [%s] [%s]%s\n",
+		e.PR.Number, e.PR.Owner, e.PR.Repo, dep, verStr, ageStr, e.PR.Author, detail, rescueStr)
 }
 
 // AdjustColumnWidths widens each column so every value fits without truncation.

--- a/internal/process/processor.go
+++ b/internal/process/processor.go
@@ -71,6 +71,14 @@ func (p *Processor) ProcessPR(ctx context.Context, info pr.PRInfo, status *pr.PR
 		return
 	}
 
+	// On any failure outcome, look for a prior automated rescue attempt
+	// recorded on the PR (an ai-rescue marker comment) so the operator can
+	// tell "needs a first rescue" apart from "a rescue already failed here".
+	// Deferred so every failure path is covered with one call site.
+	defer func() {
+		p.attachRescueMarker(ctx, info, pullReq.GetHead().GetSHA(), status, idx)
+	}()
+
 	actualAuthor := pullReq.GetUser().GetLogin()
 	if !p.isAuthorTrusted(actualAuthor) {
 		status.Update(idx, pr.StatusUntrustedAuthor, fmt.Sprintf("author %q not trusted", actualAuthor))
@@ -273,6 +281,46 @@ func (p *Processor) isBudgetBlockedCheckRun(ctx context.Context, info pr.PRInfo,
 		messages = append(messages, a.GetMessage())
 	}
 	return isBudgetBlockOutput("", "", "", messages)
+}
+
+// attachRescueMarker looks for the newest ai-rescue marker in the PR's
+// comments and attaches it to the status entry. It only runs for failure
+// outcomes (the marker is operator triage signal: "an automated rescue
+// was already attempted here"), and it degrades silently on API errors --
+// a comment-listing failure must never change a sweep result.
+func (p *Processor) attachRescueMarker(ctx context.Context, info pr.PRInfo, headSHA string, status *pr.PRStatus, idx int) {
+	switch status.StateAt(idx) {
+	case pr.StatusFailed, pr.StatusFailedSecurity, pr.StatusConflict:
+	default:
+		return
+	}
+
+	opts := &github.IssueListCommentsOptions{
+		ListOptions: github.ListOptions{PerPage: 100},
+	}
+	var marker *pr.RescueMarker
+	for {
+		comments, resp, err := p.Client.Issues.ListComments(ctx, info.Owner, info.Repo, info.Number, opts)
+		if err != nil {
+			return
+		}
+		// Comments are returned oldest-first; the last marker found wins.
+		for _, c := range comments {
+			if m := pr.ParseRescueMarker(c.GetBody()); m != nil {
+				marker = m
+			}
+		}
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	if marker == nil {
+		return
+	}
+	marker.MarkStale(headSHA)
+	status.SetRescue(idx, marker)
 }
 
 // securityPatterns returns the normalized security-check pattern list to


### PR DESCRIPTION
## Summary

- **Age column**: every table and report now shows how long a PR has been open (`5h`/`3d`/`2w`), colorized yellow after 3 days and red after 7. Failure sections sort oldest-first, and the sweep MCP entries gain `created_at` + `age_days`. Old dependency PRs have already survived several sweeps -- they are the population most likely to need manual work.
- **ai-rescue markers**: a machine-readable HTML comment (`<!-- ai-rescue: {...} -->`) inside an ordinary PR comment records a failed automated rescue attempt (tool, outcome, reason, head SHA). Sweeps read the newest marker on failing PRs and annotate them (`[rescue failed 1d ago (klaus): ...]` in the CLI, a `rescue` object with a `stale` flag in the MCP result). The marker pins the head SHA, so a Renovate rebase automatically makes it stale and the PR becomes rescuable again. Any tool that can comment on a PR can write the marker -- no coupling to a specific agent framework.
- New `marge mark <pr-url> --outcome failed|blocked --reason ... --tool ...` command and a matching `mark` MCP tool so writers never hand-craft the marker format.

Marker fetching is lazy (failing PRs only) and degrades silently on API errors -- it can annotate but never change a sweep result. README documents both features and the previously undocumented `serve` command.

## Test plan

- [x] `go test ./...` -- marker parse/round-trip/staleness, age formatting/coloring, oldest-first sorting, PR-URL parsing
- [x] `go vet` + `golangci-lint run` clean
- [x] `marge mark --help` smoke test

Made with [Cursor](https://cursor.com)